### PR TITLE
Release/2.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowise",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "private": true,
     "homepage": "https://flowiseai.com",
     "workspaces": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowise-components",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "description": "Flowiseai Components",
     "main": "dist/src/index",
     "types": "dist/src/index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowise",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "description": "Flowiseai Server",
     "main": "dist/index",
     "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowise-ui",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "license": "SEE LICENSE IN LICENSE.md",
     "homepage": "https://flowiseai.com",
     "author": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -651,10 +651,10 @@ importers:
                 version: 16.4.5
             flowise-embed:
                 specifier: latest
-                version: 1.3.12(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+                version: 1.3.13(bufferutil@4.0.8)(utf-8-validate@6.0.4)
             flowise-embed-react:
                 specifier: latest
-                version: 1.0.2(@types/node@20.12.12)(flowise-embed@1.3.12(bufferutil@4.0.8)(utf-8-validate@6.0.4))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.71.1)(terser@5.29.1)(typescript@5.5.2)
+                version: 1.0.2(@types/node@20.12.12)(flowise-embed@1.3.13(bufferutil@4.0.8)(utf-8-validate@6.0.4))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.71.1)(terser@5.29.1)(typescript@5.5.2)
             flowise-react-json-view:
                 specifier: '*'
                 version: 1.21.7(@types/react@18.2.65)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -8859,8 +8859,8 @@ packages:
             flowise-embed: '*'
             react: 18.x
 
-    flowise-embed@1.3.12:
-        resolution: { integrity: sha512-LEsk+Hq4wb9WOxDptzDN42BRgbUOG+6RwTZI4+IhwLkqCIDE1YuGVboJu2gSc2Pla6S599KnHv1/PyeQs/YUiQ== }
+    flowise-embed@1.3.13:
+        resolution: { integrity: sha512-5RnmeIwus4X9cQawJnZdMYlgdYcC+aCkD8YGF3zRfyspoc+9N+zqyH9B7XKMf4ak/lcVA+fmkP2PkXyYetqUng== }
 
     flowise-react-json-view@1.21.7:
         resolution: { integrity: sha512-oFjwtSLJkUWk6waLh8heCQ4o9b60FJRA2X8LefaZp5WaJvj/Rr2HILjk+ocf1JkfTcq8jc6t2jfIybg4leWsaQ== }
@@ -28229,10 +28229,10 @@ snapshots:
 
     flatted@3.3.1: {}
 
-    flowise-embed-react@1.0.2(@types/node@20.12.12)(flowise-embed@1.3.12(bufferutil@4.0.8)(utf-8-validate@6.0.4))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.71.1)(terser@5.29.1)(typescript@5.5.2):
+    flowise-embed-react@1.0.2(@types/node@20.12.12)(flowise-embed@1.3.13(bufferutil@4.0.8)(utf-8-validate@6.0.4))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.71.1)(terser@5.29.1)(typescript@5.5.2):
         dependencies:
             '@ladle/react': 2.5.1(@types/node@20.12.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.71.1)(terser@5.29.1)(typescript@5.5.2)
-            flowise-embed: 1.3.12(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+            flowise-embed: 1.3.13(bufferutil@4.0.8)(utf-8-validate@6.0.4)
             react: 18.2.0
         transitivePeerDependencies:
             - '@types/node'
@@ -28246,7 +28246,7 @@ snapshots:
             - terser
             - typescript
 
-    flowise-embed@1.3.12(bufferutil@4.0.8)(utf-8-validate@6.0.4):
+    flowise-embed@1.3.13(bufferutil@4.0.8)(utf-8-validate@6.0.4):
         dependencies:
             '@babel/core': 7.24.0
             '@ts-stack/markdown': 1.5.0


### PR DESCRIPTION
Release/2.0.7

SynapseFlow@2.0.7 patch bugfix release

Chore/update SynapseFlow embed version@1.3.13 (#26)

* update SynapseFlow-embed version on lock file

* add agent messages to share chatbot

* Update pnpm-lock.yaml

* update SynapseFlow-embed version

* update SynapseFlow-embed to 1.3.9