### PR TITLE
Chore/update SynapseFlow embed version to 2.0.0 (#38)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -658,10 +658,10 @@ importers:
                 version: 16.4.5
             flowise-embed:
                 specifier: latest
-                version: 1.3.13(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+                version: 2.0.0
             flowise-embed-react:
                 specifier: latest
-                version: 1.0.2(@types/node@20.12.12)(flowise-embed@1.3.13(bufferutil@4.0.8)(utf-8-validate@6.0.4))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.71.1)(terser@5.29.1)(typescript@5.5.2)
+                version: 1.0.2(@types/node@20.12.12)(flowise-embed@2.0.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.71.1)(terser@5.29.1)(typescript@5.5.2)
             flowise-react-json-view:
                 specifier: '*'
                 version: 1.21.7(@types/react@18.2.65)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -8391,8 +8391,8 @@ packages:
             flowise-embed: '*'
             react: 18.x
 
-    flowise-embed@1.3.13:
-        resolution: { integrity: sha512-5RnmeIwus4X9cQawJnZdMYlgdYcC+aCkD8YGF3zRfyspoc+9N+zqyH9B7XKMf4ak/lcVA+fmkP2PkXyYetqUng== }
+    flowise-embed@2.0.0:
+        resolution: { integrity: sha512-HzkcDaakPwXPbyimm2dFcwh3947BevpY3GY1Zrynb6Wn2+6j0o/kmbYY8LzLUaNFiEWhnO+kW44i27rtVu5ryQ== }
 
     flowise-react-json-view@1.21.7:
         resolution: { integrity: sha512-oFjwtSLJkUWk6waLh8heCQ4o9b60FJRA2X8LefaZp5WaJvj/Rr2HILjk+ocf1JkfTcq8jc6t2jfIybg4leWsaQ== }
@@ -26110,10 +26110,10 @@ snapshots:
 
     flatted@3.3.1: {}
 
-    flowise-embed-react@1.0.2(@types/node@20.12.12)(flowise-embed@1.3.13(bufferutil@4.0.8)(utf-8-validate@6.0.4))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.71.1)(terser@5.29.1)(typescript@5.5.2):
+    flowise-embed-react@1.0.2(@types/node@20.12.12)(flowise-embed@2.0.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.71.1)(terser@5.29.1)(typescript@5.5.2):
         dependencies:
             '@ladle/react': 2.5.1(@types/node@20.12.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.71.1)(terser@5.29.1)(typescript@5.5.2)
-            flowise-embed: 1.3.13(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+            flowise-embed: 2.0.0
             react: 18.2.0
         transitivePeerDependencies:
             - '@types/node'
@@ -26127,21 +26127,19 @@ snapshots:
             - terser
             - typescript
 
-    flowise-embed@1.3.13(bufferutil@4.0.8)(utf-8-validate@6.0.4):
+    flowise-embed@2.0.0:
         dependencies:
             '@babel/core': 7.24.0
+            '@microsoft/fetch-event-source': 2.0.1
             '@ts-stack/markdown': 1.5.0
             device-detector-js: 3.0.3
             lodash: 4.17.21
             prettier: 3.2.5
-            socket.io-client: 4.7.4(bufferutil@4.0.8)(utf-8-validate@6.0.4)
             solid-element: 1.7.0(solid-js@1.7.1)
             solid-js: 1.7.1
             zod: 3.23.8
         transitivePeerDependencies:
-            - bufferutil
             - supports-color
-            - utf-8-validate
 
     flowise-react-json-view@1.21.7(@types/react@18.2.65)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
         dependencies:


### PR DESCRIPTION
Chore/update SynapseFlow embed version to 2.0.0 (#38)

* update SynapseFlow-embed version on lock file

* add agent messages to share chatbot

* Update pnpm-lock.yaml

* update SynapseFlow-embed version

* update SynapseFlow-embed to 1.3.9

* update embed version to 2.0