### PR TITLE
Bugfix/Add artifacts migration script to other database types

### DIFF
--- a/packages/components/credentials/E2B.credential.ts
+++ b/packages/components/credentials/E2B.credential.ts
@@ -1,5 +1,3 @@
-/*
-* TODO: Implement codeInterpreter column to chat_message table
 import { INodeParams, INodeCredential } from '../src/Interface'
 
 class E2BApi implements INodeCredential {
@@ -23,4 +21,3 @@ class E2BApi implements INodeCredential {
 }
 
 module.exports = { credClass: E2BApi }
-*/

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowise-components",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "Flowiseai Components",
     "main": "dist/src/index",
     "types": "dist/src/index.d.ts",

--- a/packages/server/src/database/migrations/mariadb/1726156258465-AddArtifactsToChatMessage.ts
+++ b/packages/server/src/database/migrations/mariadb/1726156258465-AddArtifactsToChatMessage.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddArtifactsToChatMessage1726156258465 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const columnExists = await queryRunner.hasColumn('chat_message', 'artifacts')
+        if (!columnExists) queryRunner.query(`ALTER TABLE \`chat_message\` ADD COLUMN \`artifacts\` LONGTEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_message\` DROP COLUMN \`artifacts\`;`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/index.ts
+++ b/packages/server/src/database/migrations/mariadb/index.ts
@@ -24,6 +24,7 @@ import { AddApiKey1720230151480 } from './1720230151480-AddApiKey'
 import { AddActionToChatMessage1721078251523 } from './1721078251523-AddActionToChatMessage'
 import { LongTextColumn1722301395521 } from './1722301395521-LongTextColumn'
 import { AddCustomTemplate1725629836652 } from './1725629836652-AddCustomTemplate'
+import { AddArtifactsToChatMessage1726156258465 } from './1726156258465-AddArtifactsToChatMessage'
 
 export const mariadbMigrations = [
     Init1693840429259,
@@ -51,5 +52,6 @@ export const mariadbMigrations = [
     AddApiKey1720230151480,
     AddActionToChatMessage1721078251523,
     LongTextColumn1722301395521,
-    AddCustomTemplate1725629836652
+    AddCustomTemplate1725629836652,
+    AddArtifactsToChatMessage1726156258465
 ]

--- a/packages/server/src/database/migrations/mysql/1726156258465-AddArtifactsToChatMessage.ts
+++ b/packages/server/src/database/migrations/mysql/1726156258465-AddArtifactsToChatMessage.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddArtifactsToChatMessage1726156258465 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const columnExists = await queryRunner.hasColumn('chat_message', 'artifacts')
+        if (!columnExists) queryRunner.query(`ALTER TABLE \`chat_message\` ADD COLUMN \`artifacts\` LONGTEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_message\` DROP COLUMN \`artifacts\`;`)
+    }
+}

--- a/packages/server/src/database/migrations/mysql/index.ts
+++ b/packages/server/src/database/migrations/mysql/index.ts
@@ -25,6 +25,7 @@ import { AddApiKey1720230151480 } from './1720230151480-AddApiKey'
 import { AddActionToChatMessage1721078251523 } from './1721078251523-AddActionToChatMessage'
 import { LongTextColumn1722301395521 } from './1722301395521-LongTextColumn'
 import { AddCustomTemplate1725629836652 } from './1725629836652-AddCustomTemplate'
+import { AddArtifactsToChatMessage1726156258465 } from './1726156258465-AddArtifactsToChatMessage'
 
 export const mysqlMigrations = [
     Init1693840429259,
@@ -53,5 +54,6 @@ export const mysqlMigrations = [
     AddApiKey1720230151480,
     AddActionToChatMessage1721078251523,
     LongTextColumn1722301395521,
-    AddCustomTemplate1725629836652
+    AddCustomTemplate1725629836652,
+    AddArtifactsToChatMessage1726156258465
 ]

--- a/packages/server/src/database/migrations/postgres/1726156258465-AddArtifactsToChatMessage.ts
+++ b/packages/server/src/database/migrations/postgres/1726156258465-AddArtifactsToChatMessage.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddArtifactsToChatMessage1726156258465 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "chat_message" ADD COLUMN IF NOT EXISTS "artifacts" TEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "chat_message" DROP COLUMN "artifacts";`)
+    }
+}

--- a/packages/server/src/database/migrations/postgres/index.ts
+++ b/packages/server/src/database/migrations/postgres/index.ts
@@ -25,6 +25,7 @@ import { AddTypeToChatFlow1716300000000 } from './1716300000000-AddTypeToChatFlo
 import { AddApiKey1720230151480 } from './1720230151480-AddApiKey'
 import { AddActionToChatMessage1721078251523 } from './1721078251523-AddActionToChatMessage'
 import { AddCustomTemplate1725629836652 } from './1725629836652-AddCustomTemplate'
+import { AddArtifactsToChatMessage1726156258465 } from './1726156258465-AddArtifactsToChatMessage'
 
 export const postgresMigrations = [
     Init1693891895163,
@@ -53,5 +54,6 @@ export const postgresMigrations = [
     AddVectorStoreConfigToDocStore1715861032479,
     AddApiKey1720230151480,
     AddActionToChatMessage1721078251523,
-    AddCustomTemplate1725629836652
+    AddCustomTemplate1725629836652,
+    AddArtifactsToChatMessage1726156258465
 ]


### PR DESCRIPTION
Bugfix/Add artifacts migration script to other database types

add artifacts migration script to other database types

Release/2.1.0

* SynapseFlow@2.1.0 release

* update SynapseFlow-components@2.1.1

Bugfix/CodeInterpreter E2B Credential (#39)

* Base changes for ServerSide Events (instead of socket.io)

* lint fixes

* adding of interface and separate methods for streaming events

* lint

* first draft, handles both internal and external prediction end points.

* lint fixes

* additional internal end point for streaming and associated changes

* return streamresponse as true to build agent flow

* 1) JSON formatting for internal events
2) other fixes

* 1) convert internal event to metadata to maintain consistency with external response

* fix action and metadata streaming

* fix for error when agent flow is aborted

* prevent subflows from streaming and other code cleanup

* prevent streaming from enclosed tools

* add fix for preventing chaintool streaming

* update lock file

* add open when hidden to sse

* Streaming errors

* Streaming errors

* add fix for showing error message

* add code interpreter

* add artifacts to view message dialog

* Update pnpm-lock.yaml

* uncomment e2b credential

---------