### PR TITLE
feat: save Chatflow title when the `ENTER` key is pressed or discard upon `ESC` is pressed

### DIFF
--- a/packages/ui/src/ui-component/dialog/SaveChatflowDialog.jsx
+++ b/packages/ui/src/ui-component/dialog/SaveChatflowDialog.jsx
@@ -40,6 +40,9 @@ const SaveChatflowDialog = ({ show, dialogProps, onCancel, onConfirm }) => {
                     placeholder='My New Chatflow'
                     value={chatflowName}
                     onChange={(e) => setChatflowName(e.target.value)}
+                    onKeyDown={(e) => {
+                        if (isReadyToSave && e.key === 'Enter') onConfirm(e.target.value)
+                    }}
                 />
             </DialogContent>
             <DialogActions>

--- a/packages/ui/src/ui-component/dialog/SaveChatflowDialog.jsx
+++ b/packages/ui/src/ui-component/dialog/SaveChatflowDialog.jsx
@@ -24,12 +24,15 @@ const SaveChatflowDialog = ({ show, dialogProps, onCancel, onConfirm }) => {
             onClose={onCancel}
             aria-labelledby='alert-dialog-title'
             aria-describedby='alert-dialog-description'
+            disableRestoreFocus // needed due to StrictMode
         >
             <DialogTitle sx={{ fontSize: '1rem' }} id='alert-dialog-title'>
                 {dialogProps.title}
             </DialogTitle>
             <DialogContent>
                 <OutlinedInput
+                    // eslint-disable-next-line jsx-a11y/no-autofocus
+                    autoFocus
                     sx={{ mt: 1 }}
                     id='chatflow-name'
                     type='text'

--- a/packages/ui/src/views/canvas/CanvasHeader.jsx
+++ b/packages/ui/src/views/canvas/CanvasHeader.jsx
@@ -310,6 +310,13 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, handleSaveFlow, handleDeleteFlo
                                         ml: 2
                                     }}
                                     defaultValue={flowName}
+                                    onKeyDown={(e) => {
+                                        if (e.key === 'Enter') {
+                                            submitFlowName()
+                                        } else if (e.key === 'Escape') {
+                                            setEditingFlowName(false)
+                                        }
+                                    }}
                                 />
                                 <ButtonBase title='Save Name' sx={{ borderRadius: '50%' }}>
                                     <Avatar


### PR DESCRIPTION
feat: save Chatflow title when the `ENTER` key is pressed or discard upon `ESC` is pressed

This simple event handler improves the usability of the UI by avoiding having to use the mouse to save or dicard title changes

feat: save a new Chatflow when the `ENTER` key is pressed

This simple event handler improve the usability of the UI by avoiding having to use the mouse or having to tab twice and then hit enter to save a flow

feat: enable autofocus to the `new chatflow title` to improve usability (#47)

This dialog has only one input and it is the primary one, there is no need for an extra click to be able to set the title