### PR TITLE
fix: warning when a non-boolean values was used to set `checked` prop of a SwitchInput component

### DIFF
--- a/packages/ui/src/layout/MainLayout/ViewHeader.jsx
+++ b/packages/ui/src/layout/MainLayout/ViewHeader.jsx
@@ -10,6 +10,12 @@ import { StyledFab } from '@/ui-component/button/StyledFab'
 import { IconSearch, IconArrowLeft, IconEdit } from '@tabler/icons-react'
 
 import useSearchShorcut from '@/hooks/useSearchShortcut'
+import { getOS } from '@/utils/genericHelper'
+
+const os = getOS()
+const isMac = os === 'macos'
+const isDesktop = isMac || os === 'windows' || os === 'linux'
+const keyboardShortcut = isMac ? '[ ⌘ + F ]' : '[ Ctrl + F ]'
 
 const ViewHeader = ({
     children,
@@ -93,7 +99,7 @@ const ViewHeader = ({
                             inputRef={searchInputRef}
                             size='small'
                             sx={{
-                                width: '280px',
+                                width: '325px',
                                 height: '100%',
                                 display: { xs: 'none', sm: 'flex' },
                                 borderRadius: 2,
@@ -103,7 +109,7 @@ const ViewHeader = ({
                                 }
                             }}
                             variant='outlined'
-                            placeholder={searchPlaceholder}
+                            placeholder={`${searchPlaceholder} ${isDesktop ? keyboardShortcut : ''}`}
                             onChange={onSearchChange}
                             startAdornment={
                                 <Box

--- a/packages/ui/src/ui-component/switch/Switch.jsx
+++ b/packages/ui/src/ui-component/switch/Switch.jsx
@@ -6,7 +6,7 @@ export const SwitchInput = ({ label, value, onChange, disabled = false }) => {
     const [myValue, setMyValue] = useState(value !== undefined ? !!value : false)
 
     useEffect(() => {
-        setMyValue(value)
+        setMyValue(value !== undefined ? !!value : false)
     }, [value])
 
     return (


### PR DESCRIPTION
fix: warning when a non-boolean values was used to set `checked` prop of a SwitchInput component

fix: warning when a non-boolean values was used to set`checked` prop of SwitchInput component

The problem was that in the useEffect hook the plain value was used without validation like in useState

feat: add shortcut text hint to the search field (#50)

* feat: add shortcut text hint to the search field

* fix: search box width to fit the shortcut hint text

* fix: error when not running on Mac due to an undefined `os` variable