### PR TITLE
Added S3_FORCE_PATH_STYLE environment variable support for AWS S3 client configuration to ensure compatibility with custom S3 endpoints and path-style URLs. This change sets the forcePathStyle option based on the environment variable, defaulting to false if not provided. (#55)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,7 @@ Flowise support different environment variables to configure your instance. You 
 | S3_STORAGE_SECRET_ACCESS_KEY | AWS Secret Key                                                                                  | String                                           |                                     |
 | S3_STORAGE_REGION            | Region for S3 bucket                                                                            | String                                           |                                     |
 | S3_ENDPOINT_URL              | Custom Endpoint for S3                                                                          | String                                           |                                     |
+| S3_FORCE_PATH_STYLE          | Set this to true to force the request to use path-style addressing                              | Boolean                                          | false                               |
 | SHOW_COMMUNITY_NODES         | Show nodes created by community                                                                 | Boolean                                          |                                     |
 
 You can also specify the env variables when using `npx`. For example:

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -48,6 +48,7 @@ BLOB_STORAGE_PATH=/root/.flowise/storage
 # S3_STORAGE_SECRET_ACCESS_KEY=<your-secret-key>
 # S3_STORAGE_REGION=us-west-2
 # S3_ENDPOINT_URL=<custom-s3-endpoint-url>
+# S3_FORCE_PATH_STYLE=false
 
 # APIKEY_STORAGE_TYPE=json (json | db)
 # SHOW_COMMUNITY_NODES=true

--- a/i18n/CONTRIBUTING-ZH.md
+++ b/i18n/CONTRIBUTING-ZH.md
@@ -150,6 +150,7 @@ Flowise 支持不同的环境变量来配置您的实例。您可以在 `package
 | S3_STORAGE_SECRET_ACCESS_KEY | AWS 密钥 (Secret Key)                                                | 字符串                                          |                                     |
 | S3_STORAGE_REGION            | S3 存储地区                                                          | 字符串                                          |                                     |
 | S3_ENDPOINT_URL              | S3 端点 URL                                                          | 字符串                                          |                                     |
+| S3_FORCE_PATH_STYLE          | 将其设置为 true 以强制请求使用路径样式寻址                              | Boolean                                          | false                               |
 | SHOW_COMMUNITY_NODES         | 显示由社区创建的节点                                                 | 布尔值                                          |                                     |
 
 您也可以在使用 `npx` 时指定环境变量。例如：

--- a/packages/components/src/storageUtils.ts
+++ b/packages/components/src/storageUtils.ts
@@ -331,6 +331,7 @@ export const getS3Config = () => {
     const region = process.env.S3_STORAGE_REGION
     const Bucket = process.env.S3_STORAGE_BUCKET_NAME
     const customURL = process.env.S3_ENDPOINT_URL
+    const forcePathStyle = process.env.S3_FORCE_PATH_STYLE === 'true' ? true : false
 
     if (!region || !Bucket) {
         throw new Error('S3 storage configuration is missing')
@@ -347,7 +348,8 @@ export const getS3Config = () => {
     const s3Client = new S3Client({
         credentials,
         region,
-        endpoint: customURL
+        endpoint: customURL,
+        forcePathStyle: forcePathStyle
     })
     return { s3Client, Bucket }
 }

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -48,6 +48,7 @@ PORT=3000
 # S3_STORAGE_SECRET_ACCESS_KEY=<your-secret-key>
 # S3_STORAGE_REGION=us-west-2
 # S3_ENDPOINT_URL=<custom-s3-endpoint-url>
+# S3_FORCE_PATH_STYLE=false
 
 # APIKEY_STORAGE_TYPE=json (json | db)
 # SHOW_COMMUNITY_NODES=true

--- a/packages/server/src/commands/start.ts
+++ b/packages/server/src/commands/start.ts
@@ -55,6 +55,7 @@ export default class Start extends Command {
         S3_STORAGE_SECRET_ACCESS_KEY: Flags.string(),
         S3_STORAGE_REGION: Flags.string(),
         S3_ENDPOINT_URL: Flags.string(),
+        S3_FORCE_PATH_STYLE: Flags.string(),
         SHOW_COMMUNITY_NODES: Flags.string()
     }
 
@@ -152,6 +153,7 @@ export default class Start extends Command {
         if (flags.S3_STORAGE_SECRET_ACCESS_KEY) process.env.S3_STORAGE_SECRET_ACCESS_KEY = flags.S3_STORAGE_SECRET_ACCESS_KEY
         if (flags.S3_STORAGE_REGION) process.env.S3_STORAGE_REGION = flags.S3_STORAGE_REGION
         if (flags.S3_ENDPOINT_URL) process.env.S3_ENDPOINT_URL = flags.S3_ENDPOINT_URL
+        if (flags.S3_FORCE_PATH_STYLE) process.env.S3_FORCE_PATH_STYLE = flags.S3_FORCE_PATH_STYLE
 
         await (async () => {
             try {


### PR DESCRIPTION
Added S3_FORCE_PATH_STYLE environment variable support for AWS S3 client configuration to ensure compatibility with custom S3 endpoints and path-style URLs. This change sets the forcePathStyle option based on the environment variable, defaulting to false if not provided. (#55)