### PR TITLE
Make credentials optional when env variables are set (#72)

### DIFF
--- a/packages/components/nodes/chatmodels/AzureChatOpenAI/AzureChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/AzureChatOpenAI/AzureChatOpenAI.ts
@@ -6,6 +6,12 @@ import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../
 import { ChatOpenAI } from '../ChatOpenAI/FlowiseChatOpenAI'
 import { getModels, MODEL_TYPE } from '../../../src/modelLoader'
 
+const serverCredentialsExists =
+    !!process.env.AZURE_OPENAI_API_KEY &&
+    !!process.env.AZURE_OPENAI_API_INSTANCE_NAME &&
+    !!process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME &&
+    !!process.env.AZURE_OPENAI_API_VERSION
+
 class AzureChatOpenAI_ChatModels implements INode {
     label: string
     name: string
@@ -31,7 +37,8 @@ class AzureChatOpenAI_ChatModels implements INode {
             label: 'Connect Credential',
             name: 'credential',
             type: 'credential',
-            credentialNames: ['azureOpenAIApi']
+            credentialNames: ['azureOpenAIApi'],
+            optional: serverCredentialsExists
         }
         this.inputs = [
             {

--- a/packages/components/nodes/chatmodels/AzureChatOpenAI/README.md
+++ b/packages/components/nodes/chatmodels/AzureChatOpenAI/README.md
@@ -1,0 +1,16 @@
+# Azure OpenAI Chat Model
+
+Azure OpenAI Chat Model integration for Flowise
+
+## 🌱 Env Variables
+
+| Variable                     | Description                                                                                     | Type                                             | Default                             |
+| ---------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------- |
+| AZURE_OPENAI_API_KEY    | Default `credential.azureOpenAIApiKey` for Azure OpenAI Model                                            | String                                                                    |            |
+| AZURE_OPENAI_API_INSTANCE_NAME    | Default `credential.azureOpenAIApiInstanceName` for Azure OpenAI Model                                            | String                                                                    |            |
+| AZURE_OPENAI_API_DEPLOYMENT_NAME    | Default `credential.azureOpenAIApiDeploymentName` for Azure OpenAI Model                                            | String                                                                    |            |
+| AZURE_OPENAI_API_VERSION    | Default `credential.azureOpenAIApiVersion` for Azure OpenAI Model                                            | String                                                                    |            |
+
+## License
+
+Source code in this repository is made available under the [Apache License Version 2.0](https://github.com/FlowiseAI/Flowise/blob/master/LICENSE.md).

--- a/packages/components/nodes/embeddings/AzureOpenAIEmbedding/AzureOpenAIEmbedding.ts
+++ b/packages/components/nodes/embeddings/AzureOpenAIEmbedding/AzureOpenAIEmbedding.ts
@@ -2,6 +2,12 @@ import { AzureOpenAIInput, OpenAIEmbeddings, OpenAIEmbeddingsParams } from '@lan
 import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
 import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
 
+const serverCredentialsExists =
+    !!process.env.AZURE_OPENAI_API_KEY &&
+    !!process.env.AZURE_OPENAI_API_INSTANCE_NAME &&
+    (!!process.env.AZURE_OPENAI_API_EMBEDDINGS_DEPLOYMENT_NAME || !!process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME) &&
+    !!process.env.AZURE_OPENAI_API_VERSION
+
 class AzureOpenAIEmbedding_Embeddings implements INode {
     label: string
     name: string
@@ -27,7 +33,8 @@ class AzureOpenAIEmbedding_Embeddings implements INode {
             label: 'Connect Credential',
             name: 'credential',
             type: 'credential',
-            credentialNames: ['azureOpenAIApi']
+            credentialNames: ['azureOpenAIApi'],
+            optional: serverCredentialsExists
         }
         this.inputs = [
             {

--- a/packages/components/nodes/embeddings/AzureOpenAIEmbedding/README.md
+++ b/packages/components/nodes/embeddings/AzureOpenAIEmbedding/README.md
@@ -1,0 +1,16 @@
+# Azure OpenAI Embedding Model
+
+Azure OpenAI Embedding Model integration for Flowise
+
+## 🌱 Env Variables
+
+| Variable                     | Description                                                                                     | Type                                             | Default                             |
+| ---------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------- |
+| AZURE_OPENAI_API_KEY    | Default `credential.azureOpenAIApiKey` for Azure OpenAI Model                                            | String                                                                    |            |
+| AZURE_OPENAI_API_INSTANCE_NAME    | Default `credential.azureOpenAIApiInstanceName` for Azure OpenAI Model                                            | String                                                                    |            |
+| AZURE_OPENAI_API_EMBEDDINGS_DEPLOYMENT_NAME    | Default `credential.azureOpenAIApiDeploymentName` for Azure OpenAI Model                                            | String                                                                    |            |
+| AZURE_OPENAI_API_VERSION    | Default `credential.azureOpenAIApiVersion` for Azure OpenAI Model                                            | String                                                                    |            |
+
+## License
+
+Source code in this repository is made available under the [Apache License Version 2.0](https://github.com/FlowiseAI/Flowise/blob/master/LICENSE.md).

--- a/packages/components/nodes/llms/Azure OpenAI/AzureOpenAI.ts
+++ b/packages/components/nodes/llms/Azure OpenAI/AzureOpenAI.ts
@@ -5,6 +5,12 @@ import { ICommonObject, INode, INodeData, INodeOptionsValue, INodeParams } from 
 import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
 import { getModels, MODEL_TYPE } from '../../../src/modelLoader'
 
+const serverCredentialsExists =
+    !!process.env.AZURE_OPENAI_API_KEY &&
+    !!process.env.AZURE_OPENAI_API_INSTANCE_NAME &&
+    !!process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME &&
+    !!process.env.AZURE_OPENAI_API_VERSION
+
 class AzureOpenAI_LLMs implements INode {
     label: string
     name: string
@@ -30,7 +36,8 @@ class AzureOpenAI_LLMs implements INode {
             label: 'Connect Credential',
             name: 'credential',
             type: 'credential',
-            credentialNames: ['azureOpenAIApi']
+            credentialNames: ['azureOpenAIApi'],
+            optional: serverCredentialsExists
         }
         this.inputs = [
             {

--- a/packages/components/nodes/llms/Azure OpenAI/README.md
+++ b/packages/components/nodes/llms/Azure OpenAI/README.md
@@ -1,0 +1,16 @@
+# Azure OpenAI LLM
+
+Azure OpenAI LLM integration for Flowise
+
+## 🌱 Env Variables
+
+| Variable                     | Description                                                                                     | Type                                             | Default                             |
+| ---------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------- |
+| AZURE_OPENAI_API_KEY    | Default `credential.azureOpenAIApiKey` for Azure OpenAI LLM                                            | String                                                                    |            |
+| AZURE_OPENAI_API_INSTANCE_NAME    | Default `credential.azureOpenAIApiInstanceName` for Azure OpenAI LLM                                            | String                                                                    |            |
+| AZURE_OPENAI_API_DEPLOYMENT_NAME    | Default `credential.azureOpenAIApiDeploymentName` for Azure OpenAI LLM                                            | String                                                                    |            |
+| AZURE_OPENAI_API_VERSION    | Default `credential.azureOpenAIApiVersion` for Azure OpenAI LLM                                            | String                                                                    |            |
+
+## License
+
+Source code in this repository is made available under the [Apache License Version 2.0](https://github.com/FlowiseAI/Flowise/blob/master/LICENSE.md).


### PR DESCRIPTION
Make credentials optional when env variables are set (#72)

* Make Azure OpenAI credentials optional when env variables are set

* Add documentation for env vars