### PR TITLE
Azure OpenAI Embeddings ignores env variable AZURE_OPENAI_BASE_PATH

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -4,6 +4,11 @@
             "name": "awsChatBedrock",
             "models": [
                 {
+                    "label": "anthropic.claude-3-5-haiku-20241022-v1:0",
+                    "name": "anthropic.claude-3-5-haiku-20241022-v1:0",
+                    "description": "(20241022-v1:0) specific version of Claude Haiku 3.5 - fastest model"
+                },
+                {
                     "label": "anthropic.claude-3.5-sonnet-20241022-v2:0",
                     "name": "anthropic.claude-3-5-sonnet-20241022-v2:0",
                     "description": "(20241022-v2:0) specific version of Claude Sonnet 3.5 - most intelligent model"
@@ -300,6 +305,11 @@
             "name": "chatAnthropic",
             "models": [
                 {
+                    "label": "claude-3-5-haiku-latest",
+                    "name": "claude-3-5-haiku-latest",
+                    "description": "Most recent snapshot version of Claude Haiku 3.5 - fastest model"
+                },
+                {
                     "label": "claude-3.5-sonnet-latest",
                     "name": "claude-3-5-sonnet-latest",
                     "description": "Most recent snapshot version of Claude Sonnet 3.5 model - most intelligent model"
@@ -453,6 +463,11 @@
                 {
                     "label": "gemini-1.0-pro-vision",
                     "name": "gemini-1.0-pro-vision"
+                },
+                {
+                    "label": "claude-3-5-haiku@20241022",
+                    "name": "claude-3-5-haiku@20241022",
+                    "description": "(20241022-v1:0) specific version of Claude Haiku 3.5 - fastest model"
                 },
                 {
                     "label": "claude-3-5-sonnet-v2@20241022",
@@ -1252,6 +1267,18 @@
         {
             "name": "googlevertexaiEmbeddings",
             "models": [
+                {
+                    "label": "multimodalembedding",
+                    "name": "multimodalembedding"
+                },
+                {
+                    "label": "text-embedding-004",
+                    "name": "text-embedding-004"
+                },
+                {
+                    "label": "text-multilingual-embedding-002",
+                    "name": "text-multilingual-embedding-002"
+                },
                 {
                     "label": "textembedding-gecko@001",
                     "name": "textembedding-gecko@001"

--- a/packages/components/nodes/embeddings/AzureOpenAIEmbedding/AzureOpenAIEmbedding.ts
+++ b/packages/components/nodes/embeddings/AzureOpenAIEmbedding/AzureOpenAIEmbedding.ts
@@ -78,7 +78,7 @@ class AzureOpenAIEmbedding_Embeddings implements INode {
             azureOpenAIApiInstanceName,
             azureOpenAIApiDeploymentName,
             azureOpenAIApiVersion,
-            azureOpenAIBasePath: basePath
+            azureOpenAIBasePath: basePath || undefined
         }
 
         if (batchSize) obj.batchSize = parseInt(batchSize, 10)

--- a/packages/components/nodes/sequentialagents/commonUtils.ts
+++ b/packages/components/nodes/sequentialagents/commonUtils.ts
@@ -212,7 +212,7 @@ export const restructureMessages = (llm: BaseChatModel, state: ISeqAgentsState) 
     const messages: BaseMessage[] = []
     for (const message of state.messages as unknown as BaseMessage[]) {
         // Sometimes Anthropic can return a message with content types of array, ignore that EXECEPT when tool calls are present
-        if ((message as any).tool_calls?.length) {
+        if ((message as any).tool_calls?.length && message.content !== '') {
             message.content = JSON.stringify(message.content)
         }
 


### PR DESCRIPTION
Azure OpenAI Embeddings ignores env variable AZURE_OPENAI_BASE_PATH

* Set azureOpenAIBasePath to undefined if empty to enforce usage of env variable AZURE_OPENAI_BASE_PATH in @langchain+openai@0.0.30_encoding@0.1.13_langchain@0.2.11/node_modules/@langchain/openai/dist/embeddings.cjs

Update commonUtils.ts

Fixed a bug in `restructureMessages` leading to blowing up of the message content with escape characters and eventually crashing the flow with "repetitive patterns" error

Chore/Add Haiku 3.5 (#73)

* add gemini flash

* add gemin flash to vertex

* add gemin-1.5-flash-preview to vertex

* add azure gpt 4o

* add claude 3.5 sonnet

* add mistral nemo

* add groq llama3.1

* add gpt4o-mini to azure

* o1 mini

* add groq llama 3.2

* update anthropic models

* add 3.5 haiku

* update vertex embedding models