### PR TITLE
Bugfix/Prevent open connections on typeorm datasource

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -498,6 +498,14 @@
             "name": "groqChat",
             "models": [
                 {
+                    "label": "llama-3.3-70b-versatile",
+                    "name": "llama-3.3-70b-versatile"
+                },
+                {
+                    "label": "llama-3.3-70b-specdec",
+                    "name": "llama-3.3-70b-specdec"
+                },
+                {
                     "label": "llama-3.2-1b-preview",
                     "name": "llama-3.2-1b-preview"
                 },

--- a/packages/components/nodes/memory/AgentMemory/MySQLAgentMemory/mysqlSaver.ts
+++ b/packages/components/nodes/memory/AgentMemory/MySQLAgentMemory/mysqlSaver.ts
@@ -21,6 +21,13 @@ export class MySQLSaver extends BaseCheckpointSaver implements MemoryMethods {
 
     private async getDataSource(): Promise<DataSource> {
         const { datasourceOptions } = this.config
+        if (!datasourceOptions) {
+            throw new Error('No datasource options provided')
+        }
+        // Prevent using default Postgres port, otherwise will throw uncaught error and crashing the app
+        if (datasourceOptions.port === 5432) {
+            throw new Error('Invalid port number')
+        }
         const dataSource = new DataSource(datasourceOptions)
         await dataSource.initialize()
         return dataSource

--- a/packages/components/nodes/memory/AgentMemory/PostgresAgentMemory/pgSaver.ts
+++ b/packages/components/nodes/memory/AgentMemory/PostgresAgentMemory/pgSaver.ts
@@ -21,6 +21,13 @@ export class PostgresSaver extends BaseCheckpointSaver implements MemoryMethods 
 
     private async getDataSource(): Promise<DataSource> {
         const { datasourceOptions } = this.config
+        if (!datasourceOptions) {
+            throw new Error('No datasource options provided')
+        }
+        // Prevent using default MySQL port, otherwise will throw uncaught error and crashing the app
+        if (datasourceOptions.port === 3006) {
+            throw new Error('Invalid port number')
+        }
         const dataSource = new DataSource(datasourceOptions)
         await dataSource.initialize()
         return dataSource

--- a/packages/components/nodes/memory/AgentMemory/SQLiteAgentMemory/sqliteSaver.ts
+++ b/packages/components/nodes/memory/AgentMemory/SQLiteAgentMemory/sqliteSaver.ts
@@ -1,42 +1,39 @@
 import { BaseCheckpointSaver, Checkpoint, CheckpointMetadata } from '@langchain/langgraph'
 import { RunnableConfig } from '@langchain/core/runnables'
 import { BaseMessage } from '@langchain/core/messages'
-import { DataSource, QueryRunner } from 'typeorm'
+import { DataSource } from 'typeorm'
 import { CheckpointTuple, SaverOptions, SerializerProtocol } from '../interface'
 import { IMessage, MemoryMethods } from '../../../../src/Interface'
 import { mapChatMessageToBaseMessage } from '../../../../src/utils'
 
 export class SqliteSaver extends BaseCheckpointSaver implements MemoryMethods {
     protected isSetup: boolean
-
-    datasource: DataSource
-
-    queryRunner: QueryRunner
-
     config: SaverOptions
-
     threadId: string
-
     tableName = 'checkpoints'
 
     constructor(config: SaverOptions, serde?: SerializerProtocol<Checkpoint>) {
         super(serde)
         this.config = config
-        const { datasourceOptions, threadId } = config
+        const { threadId } = config
         this.threadId = threadId
-        this.datasource = new DataSource(datasourceOptions)
     }
 
-    private async setup(): Promise<void> {
+    private async getDataSource(): Promise<DataSource> {
+        const { datasourceOptions } = this.config
+        const dataSource = new DataSource(datasourceOptions)
+        await dataSource.initialize()
+        return dataSource
+    }
+
+    private async setup(dataSource: DataSource): Promise<void> {
         if (this.isSetup) {
             return
         }
 
         try {
-            const appDataSource = await this.datasource.initialize()
-
-            this.queryRunner = appDataSource.createQueryRunner()
-            await this.queryRunner.manager.query(`
+            const queryRunner = dataSource.createQueryRunner()
+            await queryRunner.manager.query(`
 CREATE TABLE IF NOT EXISTS ${this.tableName} (
     thread_id TEXT NOT NULL,
     checkpoint_id TEXT NOT NULL,
@@ -44,6 +41,7 @@ CREATE TABLE IF NOT EXISTS ${this.tableName} (
     checkpoint BLOB,
     metadata BLOB,
     PRIMARY KEY (thread_id, checkpoint_id));`)
+            await queryRunner.release()
         } catch (error) {
             console.error(`Error creating ${this.tableName} table`, error)
             throw new Error(`Error creating ${this.tableName} table`)
@@ -53,16 +51,20 @@ CREATE TABLE IF NOT EXISTS ${this.tableName} (
     }
 
     async getTuple(config: RunnableConfig): Promise<CheckpointTuple | undefined> {
-        await this.setup()
+        const dataSource = await this.getDataSource()
+        await this.setup(dataSource)
+
         const thread_id = config.configurable?.thread_id || this.threadId
         const checkpoint_id = config.configurable?.checkpoint_id
 
         if (checkpoint_id) {
             try {
+                const queryRunner = dataSource.createQueryRunner()
                 const keys = [thread_id, checkpoint_id]
                 const sql = `SELECT checkpoint, parent_id, metadata FROM ${this.tableName} WHERE thread_id = ? AND checkpoint_id = ?`
 
-                const rows = await this.queryRunner.manager.query(sql, [...keys])
+                const rows = await queryRunner.manager.query(sql, [...keys])
+                await queryRunner.release()
 
                 if (rows && rows.length > 0) {
                     return {
@@ -82,39 +84,53 @@ CREATE TABLE IF NOT EXISTS ${this.tableName} (
             } catch (error) {
                 console.error(`Error retrieving ${this.tableName}`, error)
                 throw new Error(`Error retrieving ${this.tableName}`)
+            } finally {
+                await dataSource.destroy()
             }
         } else {
-            const keys = [thread_id]
-            const sql = `SELECT thread_id, checkpoint_id, parent_id, checkpoint, metadata FROM ${this.tableName} WHERE thread_id = ? ORDER BY checkpoint_id DESC LIMIT 1`
+            try {
+                const queryRunner = dataSource.createQueryRunner()
+                const keys = [thread_id]
+                const sql = `SELECT thread_id, checkpoint_id, parent_id, checkpoint, metadata FROM ${this.tableName} WHERE thread_id = ? ORDER BY checkpoint_id DESC LIMIT 1`
 
-            const rows = await this.queryRunner.manager.query(sql, [...keys])
+                const rows = await queryRunner.manager.query(sql, [...keys])
+                await queryRunner.release()
 
-            if (rows && rows.length > 0) {
-                return {
-                    config: {
-                        configurable: {
-                            thread_id: rows[0].thread_id,
-                            checkpoint_id: rows[0].checkpoint_id
-                        }
-                    },
-                    checkpoint: (await this.serde.parse(rows[0].checkpoint)) as Checkpoint,
-                    metadata: (await this.serde.parse(rows[0].metadata)) as CheckpointMetadata,
-                    parentConfig: rows[0].parent_id
-                        ? {
-                              configurable: {
-                                  thread_id: rows[0].thread_id,
-                                  checkpoint_id: rows[0].parent_id
+                if (rows && rows.length > 0) {
+                    return {
+                        config: {
+                            configurable: {
+                                thread_id: rows[0].thread_id,
+                                checkpoint_id: rows[0].checkpoint_id
+                            }
+                        },
+                        checkpoint: (await this.serde.parse(rows[0].checkpoint)) as Checkpoint,
+                        metadata: (await this.serde.parse(rows[0].metadata)) as CheckpointMetadata,
+                        parentConfig: rows[0].parent_id
+                            ? {
+                                  configurable: {
+                                      thread_id: rows[0].thread_id,
+                                      checkpoint_id: rows[0].parent_id
+                                  }
                               }
-                          }
-                        : undefined
+                            : undefined
+                    }
                 }
+            } catch (error) {
+                console.error(`Error retrieving ${this.tableName}`, error)
+                throw new Error(`Error retrieving ${this.tableName}`)
+            } finally {
+                await dataSource.destroy()
             }
         }
         return undefined
     }
 
     async *list(config: RunnableConfig, limit?: number, before?: RunnableConfig): AsyncGenerator<CheckpointTuple> {
-        await this.setup()
+        const dataSource = await this.getDataSource()
+        await this.setup(dataSource)
+
+        const queryRunner = dataSource.createQueryRunner()
         const thread_id = config.configurable?.thread_id || this.threadId
         let sql = `SELECT thread_id, checkpoint_id, parent_id, checkpoint, metadata FROM ${this.tableName} WHERE thread_id = ? ${
             before ? 'AND checkpoint_id < ?' : ''
@@ -125,7 +141,8 @@ CREATE TABLE IF NOT EXISTS ${this.tableName} (
         const args = [thread_id, before?.configurable?.checkpoint_id].filter(Boolean)
 
         try {
-            const rows = await this.queryRunner.manager.query(sql, [...args])
+            const rows = await queryRunner.manager.query(sql, [...args])
+            await queryRunner.release()
 
             if (rows && rows.length > 0) {
                 for (const row of rows) {
@@ -152,13 +169,18 @@ CREATE TABLE IF NOT EXISTS ${this.tableName} (
         } catch (error) {
             console.error(`Error listing ${this.tableName}`, error)
             throw new Error(`Error listing ${this.tableName}`)
+        } finally {
+            await dataSource.destroy()
         }
     }
 
     async put(config: RunnableConfig, checkpoint: Checkpoint, metadata: CheckpointMetadata): Promise<RunnableConfig> {
-        await this.setup()
+        const dataSource = await this.getDataSource()
+        await this.setup(dataSource)
+
         if (!config.configurable?.checkpoint_id) return {}
         try {
+            const queryRunner = dataSource.createQueryRunner()
             const row = [
                 config.configurable?.thread_id || this.threadId,
                 checkpoint.id,
@@ -169,10 +191,13 @@ CREATE TABLE IF NOT EXISTS ${this.tableName} (
 
             const query = `INSERT OR REPLACE INTO ${this.tableName} (thread_id, checkpoint_id, parent_id, checkpoint, metadata) VALUES (?, ?, ?, ?, ?)`
 
-            await this.queryRunner.manager.query(query, row)
+            await queryRunner.manager.query(query, row)
+            await queryRunner.release()
         } catch (error) {
             console.error('Error saving checkpoint', error)
             throw new Error('Error saving checkpoint')
+        } finally {
+            await dataSource.destroy()
         }
 
         return {
@@ -187,13 +212,20 @@ CREATE TABLE IF NOT EXISTS ${this.tableName} (
         if (!threadId) {
             return
         }
-        await this.setup()
+
+        const dataSource = await this.getDataSource()
+        await this.setup(dataSource)
+
         const query = `DELETE FROM "${this.tableName}" WHERE thread_id = ?;`
 
         try {
-            await this.queryRunner.manager.query(query, [threadId])
+            const queryRunner = dataSource.createQueryRunner()
+            await queryRunner.manager.query(query, [threadId])
+            await queryRunner.release()
         } catch (error) {
             console.error(`Error deleting thread_id ${threadId}`, error)
+        } finally {
+            await dataSource.destroy()
         }
     }
 

--- a/packages/components/nodes/recordmanager/SQLiteRecordManager/SQLiteRecordManager.ts
+++ b/packages/components/nodes/recordmanager/SQLiteRecordManager/SQLiteRecordManager.ts
@@ -1,7 +1,7 @@
 import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
-import { getBaseClasses } from '../../../src/utils'
+import { getBaseClasses, getUserHome } from '../../../src/utils'
 import { ListKeyOptions, RecordManagerInterface, UpdateOptions } from '@langchain/community/indexes/base'
-import { DataSource, QueryRunner } from 'typeorm'
+import { DataSource } from 'typeorm'
 import path from 'path'
 
 class SQLiteRecordManager_RecordManager implements INode {
@@ -19,19 +19,19 @@ class SQLiteRecordManager_RecordManager implements INode {
     constructor() {
         this.label = 'SQLite Record Manager'
         this.name = 'SQLiteRecordManager'
-        this.version = 1.0
+        this.version = 1.1
         this.type = 'SQLite RecordManager'
         this.icon = 'sqlite.png'
         this.category = 'Record Manager'
         this.description = 'Use SQLite to keep track of document writes into the vector databases'
         this.baseClasses = [this.type, 'RecordManager', ...getBaseClasses(SQLiteRecordManager)]
         this.inputs = [
-            {
+            /*{
                 label: 'Database File Path',
                 name: 'databaseFilePath',
                 type: 'string',
                 placeholder: 'C:\\Users\\User\\.flowise\\database.sqlite'
-            },
+            },*/
             {
                 label: 'Additional Connection Configuration',
                 name: 'additionalConfig',
@@ -106,7 +106,6 @@ class SQLiteRecordManager_RecordManager implements INode {
         const cleanup = nodeData.inputs?.cleanup as string
         const _sourceIdKey = nodeData.inputs?.sourceIdKey as string
         const sourceIdKey = _sourceIdKey ? _sourceIdKey : 'source'
-        const databaseFilePath = nodeData.inputs?.databaseFilePath as string
 
         let additionalConfiguration = {}
         if (additionalConfig) {
@@ -117,10 +116,12 @@ class SQLiteRecordManager_RecordManager implements INode {
             }
         }
 
+        const database = path.join(process.env.DATABASE_PATH ?? path.join(getUserHome(), '.flowise'), 'database.sqlite')
+
         const sqliteOptions = {
+            database,
             ...additionalConfiguration,
-            type: 'sqlite',
-            database: path.resolve(databaseFilePath)
+            type: 'sqlite'
         }
 
         const args = {
@@ -144,29 +145,33 @@ type SQLiteRecordManagerOptions = {
 
 class SQLiteRecordManager implements RecordManagerInterface {
     lc_namespace = ['langchain', 'recordmanagers', 'sqlite']
-
-    datasource: DataSource
-
-    queryRunner: QueryRunner
-
     tableName: string
-
     namespace: string
+    config: SQLiteRecordManagerOptions
 
     constructor(namespace: string, config: SQLiteRecordManagerOptions) {
-        const { sqliteOptions, tableName } = config
+        const { tableName } = config
         this.namespace = namespace
         this.tableName = tableName || 'upsertion_records'
-        this.datasource = new DataSource(sqliteOptions)
+        this.config = config
+    }
+
+    private async getDataSource(): Promise<DataSource> {
+        const { sqliteOptions } = this.config
+        if (!sqliteOptions) {
+            throw new Error('No datasource options provided')
+        }
+        const dataSource = new DataSource(sqliteOptions)
+        await dataSource.initialize()
+        return dataSource
     }
 
     async createSchema(): Promise<void> {
         try {
-            const appDataSource = await this.datasource.initialize()
+            const dataSource = await this.getDataSource()
+            const queryRunner = dataSource.createQueryRunner()
 
-            this.queryRunner = appDataSource.createQueryRunner()
-
-            await this.queryRunner.manager.query(`
+            await queryRunner.manager.query(`
 CREATE TABLE IF NOT EXISTS "${this.tableName}" (
   uuid TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
   key TEXT NOT NULL,
@@ -179,6 +184,8 @@ CREATE INDEX IF NOT EXISTS updated_at_index ON "${this.tableName}" (updated_at);
 CREATE INDEX IF NOT EXISTS key_index ON "${this.tableName}" (key);
 CREATE INDEX IF NOT EXISTS namespace_index ON "${this.tableName}" (namespace);
 CREATE INDEX IF NOT EXISTS group_id_index ON "${this.tableName}" (group_id);`)
+
+            await queryRunner.release()
         } catch (e: any) {
             // This error indicates that the table already exists
             // Due to asynchronous nature of the code, it is possible that
@@ -192,12 +199,17 @@ CREATE INDEX IF NOT EXISTS group_id_index ON "${this.tableName}" (group_id);`)
     }
 
     async getTime(): Promise<number> {
+        const dataSource = await this.getDataSource()
         try {
-            const res = await this.queryRunner.manager.query(`SELECT strftime('%s', 'now') AS epoch`)
+            const queryRunner = dataSource.createQueryRunner()
+            const res = await queryRunner.manager.query(`SELECT strftime('%s', 'now') AS epoch`)
+            await queryRunner.release()
             return Number.parseFloat(res[0].epoch)
         } catch (error) {
             console.error('Error getting time in SQLiteRecordManager:')
             throw error
+        } finally {
+            await dataSource.destroy()
         }
     }
 
@@ -205,6 +217,8 @@ CREATE INDEX IF NOT EXISTS group_id_index ON "${this.tableName}" (group_id);`)
         if (keys.length === 0) {
             return
         }
+        const dataSource = await this.getDataSource()
+        const queryRunner = dataSource.createQueryRunner()
 
         const updatedAt = await this.getTime()
         const { timeAtLeast, groupIds: _groupIds } = updateOptions ?? {}
@@ -231,10 +245,18 @@ CREATE INDEX IF NOT EXISTS group_id_index ON "${this.tableName}" (group_id);`)
         VALUES (?, ?, ?, ?)
         ON CONFLICT (key, namespace) DO UPDATE SET updated_at = excluded.updated_at`
 
-        // To handle multiple files upsert
-        for (const record of recordsToUpsert) {
-            // Consider using a transaction for batch operations
-            await this.queryRunner.manager.query(query, record.flat())
+        try {
+            // To handle multiple files upsert
+            for (const record of recordsToUpsert) {
+                // Consider using a transaction for batch operations
+                await queryRunner.manager.query(query, record.flat())
+            }
+            await queryRunner.release()
+        } catch (error) {
+            console.error('Error updating in SQLiteRecordManager:')
+            throw error
+        } finally {
+            await dataSource.destroy()
         }
     }
 
@@ -253,19 +275,25 @@ CREATE INDEX IF NOT EXISTS group_id_index ON "${this.tableName}" (group_id);`)
         // Initialize an array to fill with the existence checks
         const existsArray = new Array(keys.length).fill(false)
 
+        const dataSource = await this.getDataSource()
+        const queryRunner = dataSource.createQueryRunner()
+
         try {
             // Execute the query
-            const rows = await this.queryRunner.manager.query(sql, [this.namespace, ...keys.flat()])
+            const rows = await queryRunner.manager.query(sql, [this.namespace, ...keys.flat()])
             // Create a set of existing keys for faster lookup
             const existingKeysSet = new Set(rows.map((row: { key: string }) => row.key))
             // Map the input keys to booleans indicating if they exist
             keys.forEach((key, index) => {
                 existsArray[index] = existingKeysSet.has(key)
             })
+            await queryRunner.release()
             return existsArray
         } catch (error) {
             console.error('Error checking existence of keys')
             throw error // Allow the caller to handle the error
+        } finally {
+            await dataSource.destroy()
         }
     }
 
@@ -299,13 +327,19 @@ CREATE INDEX IF NOT EXISTS group_id_index ON "${this.tableName}" (group_id);`)
 
         query += ';'
 
+        const dataSource = await this.getDataSource()
+        const queryRunner = dataSource.createQueryRunner()
+
         // Directly using try/catch with async/await for cleaner flow
         try {
-            const result = await this.queryRunner.manager.query(query, values)
+            const result = await queryRunner.manager.query(query, values)
+            await queryRunner.release()
             return result.map((row: { key: string }) => row.key)
         } catch (error) {
             console.error('Error listing keys.')
             throw error // Re-throw the error to be handled by the caller
+        } finally {
+            await dataSource.destroy()
         }
     }
 
@@ -314,16 +348,22 @@ CREATE INDEX IF NOT EXISTS group_id_index ON "${this.tableName}" (group_id);`)
             return
         }
 
+        const dataSource = await this.getDataSource()
+        const queryRunner = dataSource.createQueryRunner()
+
         const placeholders = keys.map(() => '?').join(', ')
         const query = `DELETE FROM "${this.tableName}" WHERE namespace = ? AND key IN (${placeholders});`
         const values = [this.namespace, ...keys].map((v) => (typeof v !== 'string' ? `${v}` : v))
 
         // Directly using try/catch with async/await for cleaner flow
         try {
-            await this.queryRunner.manager.query(query, values)
+            await queryRunner.manager.query(query, values)
+            await queryRunner.release()
         } catch (error) {
             console.error('Error deleting keys')
             throw error // Re-throw the error to be handled by the caller
+        } finally {
+            await dataSource.destroy()
         }
     }
 }

--- a/packages/components/nodes/vectorstores/Postgres/driver/PGVector.ts
+++ b/packages/components/nodes/vectorstores/Postgres/driver/PGVector.ts
@@ -33,6 +33,11 @@ export class PGVectorDriver extends VectorStoreDriver {
                 password: password,
                 database: this.getDatabase()
             }
+
+            // Prevent using default MySQL port, otherwise will throw uncaught error and crashing the app
+            if (this.getHost() === '3006') {
+                throw new Error('Invalid port number')
+            }
         }
 
         return this._postgresConnectionOptions

--- a/packages/components/nodes/vectorstores/Postgres/driver/TypeORM.ts
+++ b/packages/components/nodes/vectorstores/Postgres/driver/TypeORM.ts
@@ -34,6 +34,11 @@ export class TypeORMDriver extends VectorStoreDriver {
                 password: password,
                 database: this.getDatabase()
             } as DataSourceOptions
+
+            // Prevent using default MySQL port, otherwise will throw uncaught error and crashing the app
+            if (this.getHost() === '3006') {
+                throw new Error('Invalid port number')
+            }
         }
         return this._postgresConnectionOptions
     }


### PR DESCRIPTION
Bugfix/Prevent open connections on typeorm datasource

prevent open connections on typeorm datasource

feat(models): add Llama 3.3 70B models to groqChat

* feat(models): add Llama 3.3 70B models to groqChat

Add Meta's latest Llama 3.3 70B models to groqChat options:
- llama-3.3-70b-versatile: New versatile model for general tasks
- llama-3.3-70b-specdec: Specialized model for specific tasks

These models offer comparable quality to Llama 3.1 405B at 1/5th the size,
with improvements in:
- Reasoning and math capabilities
- General knowledge tasks
- Instruction following
- Tool use and JSON outputs
- Code generation and feedback

* Revert minor version bump

Bugfix/SQLite agent memory node (#103)

* add dedicated agent memory nodes

* sqlite agent memory fix

* Update pnpm-lock.yaml