### PR TITLE
feat: Add options to filter conversation history messages used in sequential LLM and Agent nodes

### DIFF
--- a/packages/api-documentation/package.json
+++ b/packages/api-documentation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowise-api",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Flowise API documentation server",
     "scripts": {
         "build": "tsc",

--- a/packages/api-documentation/src/yml/swagger.yml
+++ b/packages/api-documentation/src/yml/swagger.yml
@@ -553,7 +553,7 @@ paths:
                   schema:
                       type: string
                       format: uuid
-                  description: Document store ID
+                  description: Document Store ID
             responses:
                 '200':
                     description: Successfully retrieved document store
@@ -580,7 +580,7 @@ paths:
                   schema:
                       type: string
                       format: uuid
-                  description: Document store ID
+                  description: Document Store ID
             requestBody:
                 content:
                     application/json:
@@ -613,7 +613,7 @@ paths:
                   schema:
                       type: string
                       format: uuid
-                  description: Document store ID
+                  description: Document Store ID
             responses:
                 '200':
                     description: Successfully deleted document store
@@ -638,7 +638,7 @@ paths:
                   schema:
                       type: string
                       format: uuid
-                  description: Document store ID
+                  description: Document Store ID
             requestBody:
                 content:
                     application/json:
@@ -711,7 +711,7 @@ paths:
                   schema:
                       type: string
                       format: uuid
-                  description: Document store ID
+                  description: Document Store ID
             requestBody:
                 content:
                     application/json:
@@ -752,7 +752,7 @@ paths:
                             properties:
                                 storeId:
                                     type: string
-                                    description: Document store ID
+                                    description: Document Store ID
                                     example: '603a7b51-ae7c-4b0a-8865-e454ed2f6766'
                                 query:
                                     type: string
@@ -779,6 +779,38 @@ paths:
                 '500':
                     description: Internal server error
 
+    /document-store/loader/{storeId}/{loaderId}:
+        delete:
+            tags:
+                - document-store
+            security:
+                - bearerAuth: []
+            summary: Delete specific document loader and associated chunks from document store
+            description: Delete specific document loader and associated chunks from document store. This does not delete data from vector store.
+            operationId: deleteLoaderFromDocumentStore
+            parameters:
+                - in: path
+                  name: storeId
+                  required: true
+                  schema:
+                      type: string
+                  description: Document Store ID
+                - in: path
+                  name: loaderId
+                  required: true
+                  schema:
+                      type: string
+                  description: Document Loader ID
+            responses:
+                '200':
+                    description: Successfully deleted loader from document store
+                '400':
+                    description: Invalid ID provided
+                '404':
+                    description: Document Store not found
+                '500':
+                    description: Internal server error
+
     /document-store/vectorstore/{id}:
         delete:
             tags:
@@ -798,6 +830,131 @@ paths:
             responses:
                 '200':
                     description: Successfully deleted data from vector store
+                '400':
+                    description: Invalid ID provided
+                '404':
+                    description: Document Store not found
+                '500':
+                    description: Internal server error
+
+    /document-store/chunks/{storeId}/{loaderId}/{pageNo}:
+        get:
+            tags:
+                - document-store
+            security:
+                - bearerAuth: []
+            summary: Get chunks from a specific document loader
+            description: Get chunks from a specific document loader within a document store
+            operationId: getDocumentStoreFileChunks
+            parameters:
+                - in: path
+                  name: storeId
+                  required: true
+                  schema:
+                      type: string
+                      format: uuid
+                  description: Document Store ID
+                - in: path
+                  name: loaderId
+                  required: true
+                  schema:
+                      type: string
+                      format: uuid
+                  description: Document loader ID
+                - in: path
+                  name: pageNo
+                  required: true
+                  schema:
+                      type: string
+                  description: Pagination number
+            responses:
+                '200':
+                    description: Successfully retrieved chunks from document loader
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/DocumentStoreFileChunkPagedResponse'
+                '404':
+                    description: Document store not found
+                '500':
+                    description: Internal server error
+
+    /document-store/chunks/{storeId}/{loaderId}/{chunkId}:
+        put:
+            tags:
+                - document-store
+            security:
+                - bearerAuth: []
+            summary: Update a specific chunk
+            description: Updates a specific chunk from a document loader
+            operationId: editDocumentStoreFileChunk
+            parameters:
+                - in: path
+                  name: storeId
+                  required: true
+                  schema:
+                      type: string
+                  description: Document Store ID
+                - in: path
+                  name: loaderId
+                  required: true
+                  schema:
+                      type: string
+                  description: Document Loader ID
+                - in: path
+                  name: chunkId
+                  required: true
+                  schema:
+                      type: string
+                  description: Document Chunk ID
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Document'
+                required: true
+            responses:
+                '200':
+                    description: Successfully updated chunk
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/DocumentStoreFileChunkPagedResponse'
+                '404':
+                    description: Document store not found
+                '500':
+                    description: Internal server error
+
+        delete:
+            tags:
+                - document-store
+            security:
+                - bearerAuth: []
+            summary: Delete a specific chunk from a document loader
+            description: Delete a specific chunk from a document loader
+            operationId: deleteDocumentStoreFileChunk
+            parameters:
+                - in: path
+                  name: storeId
+                  required: true
+                  schema:
+                      type: string
+                  description: Document Store ID
+                - in: path
+                  name: loaderId
+                  required: true
+                  schema:
+                      type: string
+                  description: Document Loader ID
+                - in: path
+                  name: chunkId
+                  required: true
+                  schema:
+                      type: string
+                  description: Document Chunk ID
+            responses:
+                '200':
+                    description: Successfully deleted chunk
                 '400':
                     description: Invalid ID provided
                 '404':
@@ -2049,7 +2206,7 @@ components:
                 storeId:
                     type: string
                     format: uuid
-                    description: Document store ID
+                    description: Document Store ID
                 chunkNo:
                     type: integer
                     description: Chunk number within the document

--- a/packages/components/src/Interface.ts
+++ b/packages/components/src/Interface.ts
@@ -183,6 +183,7 @@ export interface IMultiAgentNode {
 }
 
 type SeqAgentType = 'agent' | 'condition' | 'end' | 'start' | 'tool' | 'state' | 'llm'
+export type ConversationHistorySelection = 'user_question' | 'last_message' | 'all_messages' | 'empty'
 
 export interface ISeqAgentNode {
     id: string

--- a/packages/server/src/database/migrations/mariadb/1726666318346-AddFollowUpPrompts.ts
+++ b/packages/server/src/database/migrations/mariadb/1726666318346-AddFollowUpPrompts.ts
@@ -4,11 +4,12 @@ export class AddFollowUpPrompts1726666318346 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         const columnExistsInChatflow = await queryRunner.hasColumn('chat_flow', 'followUpPrompts')
         if (!columnExistsInChatflow) queryRunner.query(`ALTER TABLE \`chat_flow\` ADD COLUMN \`followUpPrompts\` TEXT;`)
-        const columnExistsInChatMessage = await queryRunner.hasColumn('chat_flow', 'followUpPrompts')
-        if (!columnExistsInChatMessage) queryRunner.query(`ALTER TABLE \`chat_flow\` ADD COLUMN \`followUpPrompts\` TEXT;`)
+        const columnExistsInChatMessage = await queryRunner.hasColumn('chat_message', 'followUpPrompts')
+        if (!columnExistsInChatMessage) queryRunner.query(`ALTER TABLE \`chat_message\` ADD COLUMN \`followUpPrompts\` TEXT;`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE \`chat_flow\` DROP COLUMN \`followUpPrompts\`;`)
+        await queryRunner.query(`ALTER TABLE \`chat_message\` DROP COLUMN \`followUpPrompts\`;`)
     }
 }


### PR DESCRIPTION
feat: Add options to filter conversation history messages used in sequential LLM and Agent nodes

* feat: Add option to disable conversation history

- Add new `disableConversationHistory` boolean parameter in LLMNodes.ts and Agent.ts to optionally skip including conversation history in prompts
- Fix potential error in Agent.ts when messages array is empty by adding null safety checks
- Improve memory efficiency by allowing stateless interactions when history isn't needed

* feat: add conversation history filtering options

Replace the disable conversation history feature with a more flexible filtering system that allows selecting:
- User question only
- Last message only
- All messages (default)
- No messages

This provides more granular control over conversation context management.

* chore: break lines

* chore: removed ending semi columns

* chore: fix eslint errors

* fix(sequentialagents): improve conversation history filtering logic

- Remove unnecessary state.messages check for user_question case
- Add proper null handling for last_message and all_messages cases
- Remove @ts-ignore comments with proper typing

* Update LLMNode.ts

* Update Agent.ts

---------

Chore/swagger update

* update swagger spec

* update api docs to include doc store file chunks

fix: followUpPrompts migration for MariaDB (#106)