### PR TITLE
feat: Add conversation history selection options to ConditionAgent node

### DIFF
--- a/packages/components/nodes/chatmodels/ChatIBMWatsonx/ChatIBMWatsonx.ts
+++ b/packages/components/nodes/chatmodels/ChatIBMWatsonx/ChatIBMWatsonx.ts
@@ -27,7 +27,7 @@ class ChatIBMWatsonx_ChatModels implements INode {
     constructor() {
         this.label = 'ChatIBMWatsonx'
         this.name = 'chatIBMWatsonx'
-        this.version = 1.0
+        this.version = 2.0
         this.type = 'ChatIBMWatsonx'
         this.icon = 'ibm.png'
         this.category = 'Chat Models'
@@ -75,6 +75,59 @@ class ChatIBMWatsonx_ChatModels implements INode {
                 step: 1,
                 optional: true,
                 additionalParams: true
+            },
+            {
+                label: 'Frequency Penalty',
+                name: 'frequencyPenalty',
+                type: 'number',
+                step: 1,
+                optional: true,
+                additionalParams: true,
+                description:
+                    "Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim."
+            },
+            {
+                label: 'Log Probs',
+                name: 'logprobs',
+                type: 'boolean',
+                default: false,
+                optional: true,
+                additionalParams: true,
+                description:
+                    'Whether to return log probabilities of the output tokens or not. If true, returns the log probabilities of each output token returned in the content of message.'
+            },
+            {
+                label: 'N',
+                name: 'n',
+                type: 'number',
+                step: 1,
+                default: 1,
+                optional: true,
+                additionalParams: true,
+                description:
+                    'How many chat completion choices to generate for each input message. Note that you will be charged based on the number of generated tokens across all of the choices. Keep n as 1 to minimize costs.'
+            },
+            {
+                label: 'Presence Penalty',
+                name: 'presencePenalty',
+                type: 'number',
+                step: 1,
+                default: 1,
+                optional: true,
+                additionalParams: true,
+                description:
+                    "Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics."
+            },
+            {
+                label: 'Top P',
+                name: 'topP',
+                type: 'number',
+                step: 0.1,
+                default: 0.1,
+                optional: true,
+                additionalParams: true,
+                description:
+                    'An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.'
             }
         ]
     }
@@ -84,6 +137,11 @@ class ChatIBMWatsonx_ChatModels implements INode {
         const temperature = nodeData.inputs?.temperature as string
         const modelName = nodeData.inputs?.modelName as string
         const maxTokens = nodeData.inputs?.maxTokens as string
+        const frequencyPenalty = nodeData.inputs?.frequencyPenalty as string
+        const logprobs = nodeData.inputs?.logprobs as boolean
+        const n = nodeData.inputs?.n as string
+        const presencePenalty = nodeData.inputs?.presencePenalty as string
+        const topP = nodeData.inputs?.topP as string
         const streaming = nodeData.inputs?.streaming as boolean
 
         const credentialData = await getCredentialData(nodeData.credential ?? '', options)
@@ -111,6 +169,11 @@ class ChatIBMWatsonx_ChatModels implements INode {
         }
         if (cache) obj.cache = cache
         if (maxTokens) obj.maxTokens = parseInt(maxTokens, 10)
+        if (frequencyPenalty) obj.frequencyPenalty = parseInt(frequencyPenalty, 10)
+        if (logprobs) obj.logprobs = logprobs
+        if (n) obj.maxTokens = parseInt(n, 10)
+        if (presencePenalty) obj.presencePenalty = parseInt(presencePenalty, 10)
+        if (topP) obj.topP = parseFloat(topP)
 
         const model = new ChatWatsonx(obj)
         return model

--- a/packages/components/nodes/sequentialagents/ConditionAgent/ConditionAgent.ts
+++ b/packages/components/nodes/sequentialagents/ConditionAgent/ConditionAgent.ts
@@ -6,6 +6,7 @@ import { RunnableSequence, RunnablePassthrough, RunnableConfig } from '@langchai
 import { BaseMessage } from '@langchain/core/messages'
 import { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import {
+    ConversationHistorySelection,
     ICommonObject,
     IDatabaseEntity,
     INode,
@@ -23,6 +24,7 @@ import {
     customGet,
     getVM,
     transformObjectPropertyToFunction,
+    filterConversationHistory,
     restructureMessages
 } from '../commonUtils'
 import { ChatGoogleGenerativeAI } from '../../chatmodels/ChatGoogleGenerativeAI/FlowiseChatGoogleGenerativeAI'
@@ -149,7 +151,7 @@ class ConditionAgent_SeqAgents implements INode {
     constructor() {
         this.label = 'Condition Agent'
         this.name = 'seqConditionAgent'
-        this.version = 2.0
+        this.version = 3.0
         this.type = 'ConditionAgent'
         this.icon = 'condition.svg'
         this.category = 'Sequential Agents'
@@ -184,6 +186,42 @@ class ConditionAgent_SeqAgents implements INode {
                 default: examplePrompt,
                 additionalParams: true,
                 optional: true
+            },
+            {
+                label: 'Conversation History',
+                name: 'conversationHistorySelection',
+                type: 'options',
+                options: [
+                    {
+                        label: 'User Question',
+                        name: 'user_question',
+                        description: 'Use the user question from the historical conversation messages as input.'
+                    },
+                    {
+                        label: 'Last Conversation Message',
+                        name: 'last_message',
+                        description: 'Use the last conversation message from the historical conversation messages as input.'
+                    },
+                    {
+                        label: 'All Conversation Messages',
+                        name: 'all_messages',
+                        description: 'Use all conversation messages from the historical conversation messages as input.'
+                    },
+                    {
+                        label: 'Empty',
+                        name: 'empty',
+                        description:
+                            'Do not use any messages from the conversation history. ' +
+                            'Ensure to use either System Prompt, Human Prompt, or Messages History.'
+                    }
+                ],
+                default: 'all_messages',
+                optional: true,
+                description:
+                    'Select which messages from the conversation history to include in the prompt. ' +
+                    'The selected messages will be inserted between the System Prompt (if defined) and ' +
+                    'Human Prompt.',
+                additionalParams: true
             },
             {
                 label: 'Human Prompt',
@@ -481,6 +519,9 @@ const runCondition = async (
         })
     }
 
+    const historySelection = (nodeData.inputs?.conversationHistorySelection || 'all_messages') as ConversationHistorySelection
+    // @ts-ignore
+    state.messages = filterConversationHistory(historySelection, input, state)
     // @ts-ignore
     state.messages = restructureMessages(model, state)
 


### PR DESCRIPTION
feat: Add conversation history selection options to ConditionAgent node

* feat: Enhance ConditionAgent with conversation history selection options

- Added a new parameter `conversationHistorySelection` to allow users to choose which messages from the conversation history to include in prompts.
- Options include: User Question, Last Conversation Message, All Conversation Messages, and Empty.
- Default selection is set to 'All Conversation Messages' for improved context management in sequential LLM and Agent nodes.

* Bump version from 2.0 to 3.0

Add missing inputs (#112)

* Add missing inputs

* Change version