### PR TITLE
Update RateLimit.jsx - link to documentation incorrect

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -498,6 +498,10 @@
             "name": "groqChat",
             "models": [
                 {
+                    "label": "deepseek-r1-distill-llama-70b",
+                    "name": "deepseek-r1-distill-llama-70b"
+                },
+                {
                     "label": "llama-3.3-70b-versatile",
                     "name": "llama-3.3-70b-versatile"
                 },

--- a/packages/ui/src/ui-component/extended/RateLimit.jsx
+++ b/packages/ui/src/ui-component/extended/RateLimit.jsx
@@ -151,7 +151,7 @@ const RateLimit = () => {
                 <TooltipWithParser
                     style={{ marginLeft: 10 }}
                     title={
-                        'Visit <a target="_blank" href="https://docs.flowiseai.com/rate-limit">Rate Limit Setup Guide</a> to set up Rate Limit correctly in your hosting environment.'
+                        'Visit <a target="_blank" href="https://docs.flowiseai.com/configuration/rate-limit">Rate Limit Setup Guide</a> to set up Rate Limit correctly in your hosting environment.'
                     }
                 />
             </Typography>


### PR DESCRIPTION
Update RateLimit.jsx - link to documentation incorrect

Current link to Rate Limit documentation is incorrect:
https://docs.SynapseFlowai.com/rate-limit

Corrected to:
https://docs.SynapseFlowai.com/configuration/rate-limit

Adding DeepSeekR1 Distill to Groq modal (#144)

adding DeepSeekr1 distill to groq