### PR TITLE
Fix: Ensure normalizeURL retains port number (#147)

### DIFF
--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -378,7 +378,8 @@ function getURLsFromHTML(htmlBody: string, baseURL: string): string[] {
  */
 function normalizeURL(urlString: string): string {
     const urlObj = new URL(urlString)
-    const hostPath = urlObj.hostname + urlObj.pathname + urlObj.search
+    const port = urlObj.port ? `:${urlObj.port}` : ''
+    const hostPath = urlObj.hostname + port + urlObj.pathname + urlObj.search
     if (hostPath.length > 0 && hostPath.slice(-1) == '/') {
         // handling trailing slash
         return hostPath.slice(0, -1)


### PR DESCRIPTION
Fix: Ensure normalizeURL retains port number (#147)

* fix: Preserve port in normalizeURL function

The normalizeURL function was previously ignoring the port in the URL.
This fix explicitly includes the port if present (e.g., `:3000`).

* fix lint problem

fix lint problem