### PR TITLE
Update DeleteDocStoreDialog.jsx - added clarification that data will also be removed from the record manager.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowise",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "private": true,
     "homepage": "https://flowiseai.com",
     "workspaces": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowise-components",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "description": "Flowiseai Components",
     "main": "dist/src/index",
     "types": "dist/src/index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowise",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "description": "Flowiseai Server",
     "main": "dist/index",
     "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowise-ui",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "license": "SEE LICENSE IN LICENSE.md",
     "homepage": "https://flowiseai.com",
     "author": {

--- a/packages/ui/src/views/docstore/DeleteDocStoreDialog.jsx
+++ b/packages/ui/src/views/docstore/DeleteDocStoreDialog.jsx
@@ -147,7 +147,7 @@ const DeleteDocStoreDialog = ({ show, dialogProps, onCancel, onDelete }) => {
                 {dialogProps.type === 'STORE' && dialogProps.recordManagerConfig && (
                     <FormControlLabel
                         control={<Checkbox checked={removeFromVS} onChange={(event) => setRemoveFromVS(event.target.checked)} />}
-                        label='Remove data from vector store'
+                        label='Remove data from vector store and record manager'
                     />
                 )}
                 {removeFromVS && (


### PR DESCRIPTION
Update DeleteDocStoreDialog.jsx - added clarification that data will also be removed from the record manager.

Added clarification that data will also be removed from the record manager.

Before:
"Remove data from vector store"

After:
"Remove data from vector store and record manager"

Note: this dialog box only appears when a record manager exists in the doc store. If it's intended to be shown regardless of whether a record manager exists, updates will be needed.

Release/2.2.5 (#149)

* release 2.2.5

* update pnpm lock file

* Update pnpm-lock.yaml

* Update pnpm-lock.yaml