### PR TITLE
Release/2.2.6-hotfix.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowise",
-    "version": "2.2.5",
+    "version": "2.2.6",
     "private": true,
     "homepage": "https://flowiseai.com",
     "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowise",
-    "version": "2.2.6",
+    "version": "2.2.6-hotfix.1",
     "private": true,
     "homepage": "https://flowiseai.com",
     "workspaces": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowise-components",
-    "version": "2.2.5",
+    "version": "2.2.6",
     "description": "Flowiseai Components",
     "main": "dist/src/index",
     "types": "dist/src/index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowise",
-    "version": "2.2.6",
+    "version": "2.2.6-hotfix.1",
     "description": "Flowiseai Server",
     "main": "dist/index",
     "types": "dist/index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowise",
-    "version": "2.2.5",
+    "version": "2.2.6",
     "description": "Flowiseai Server",
     "main": "dist/index",
     "types": "dist/index.d.ts",

--- a/packages/server/src/middlewares/errors/index.ts
+++ b/packages/server/src/middlewares/errors/index.ts
@@ -12,7 +12,7 @@ async function errorHandlerMiddleware(err: InternalFlowiseError, req: Request, r
         // Provide error stack trace only in development
         stack: process.env.NODE_ENV === 'development' ? err.stack : {}
     }
-    if (!req.body.streaming || req.body.streaming === 'false') {
+    if (!req.body || !req.body.streaming || req.body.streaming === 'false') {
         res.setHeader('Content-Type', 'application/json')
         res.status(displayedError.statusCode).json(displayedError)
     }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowise-ui",
-    "version": "2.2.5",
+    "version": "2.2.6",
     "license": "SEE LICENSE IN LICENSE.md",
     "homepage": "https://flowiseai.com",
     "author": {


### PR DESCRIPTION
Release/2.2.6-hotfix.1

SynapseFlow @2.2.6-hotfix.1

Fix for node-crashing "undefined (reading 'streaming')" error

* check for undefined variables in buildChatflow to avoid node crashing exceptions

* Add null check on error Middleware as well

Release/2.2.6 (#160)

SynapseFlow@2.2.6