### PR TITLE
Feature: add tooltip display on icon hover in chatflows and marketplace page

### DIFF
--- a/packages/components/nodes/vectorstores/Redis/Redis.ts
+++ b/packages/components/nodes/vectorstores/Redis/Redis.ts
@@ -153,8 +153,12 @@ class Redis_VectorStores implements INode {
                         keepAlive:
                             process.env.REDIS_KEEP_ALIVE && !isNaN(parseInt(process.env.REDIS_KEEP_ALIVE, 10))
                                 ? parseInt(process.env.REDIS_KEEP_ALIVE, 10)
-                                : undefined // milliseconds
-                    }
+                                : undefined
+                    },
+                    pingInterval:
+                        process.env.REDIS_KEEP_ALIVE && !isNaN(parseInt(process.env.REDIS_KEEP_ALIVE, 10))
+                            ? parseInt(process.env.REDIS_KEEP_ALIVE, 10)
+                            : undefined // Add Redis protocol-level pings
                 })
                 await redisClient.connect()
 
@@ -226,8 +230,12 @@ class Redis_VectorStores implements INode {
                 keepAlive:
                     process.env.REDIS_KEEP_ALIVE && !isNaN(parseInt(process.env.REDIS_KEEP_ALIVE, 10))
                         ? parseInt(process.env.REDIS_KEEP_ALIVE, 10)
-                        : undefined // milliseconds
-            }
+                        : undefined
+            },
+            pingInterval:
+                process.env.REDIS_KEEP_ALIVE && !isNaN(parseInt(process.env.REDIS_KEEP_ALIVE, 10))
+                    ? parseInt(process.env.REDIS_KEEP_ALIVE, 10)
+                    : undefined // Add Redis protocol-level pings
         })
 
         const storeConfig: RedisVectorStoreConfig = {

--- a/packages/server/src/queue/RedisEventPublisher.ts
+++ b/packages/server/src/queue/RedisEventPublisher.ts
@@ -13,7 +13,11 @@ export class RedisEventPublisher implements IServerSideEventStreamer {
                         process.env.REDIS_KEEP_ALIVE && !isNaN(parseInt(process.env.REDIS_KEEP_ALIVE, 10))
                             ? parseInt(process.env.REDIS_KEEP_ALIVE, 10)
                             : undefined
-                }
+                },
+                pingInterval:
+                    process.env.REDIS_KEEP_ALIVE && !isNaN(parseInt(process.env.REDIS_KEEP_ALIVE, 10))
+                        ? parseInt(process.env.REDIS_KEEP_ALIVE, 10)
+                        : undefined
             })
         } else {
             this.redisPublisher = createClient({
@@ -30,7 +34,11 @@ export class RedisEventPublisher implements IServerSideEventStreamer {
                         process.env.REDIS_KEEP_ALIVE && !isNaN(parseInt(process.env.REDIS_KEEP_ALIVE, 10))
                             ? parseInt(process.env.REDIS_KEEP_ALIVE, 10)
                             : undefined
-                }
+                },
+                pingInterval:
+                    process.env.REDIS_KEEP_ALIVE && !isNaN(parseInt(process.env.REDIS_KEEP_ALIVE, 10))
+                        ? parseInt(process.env.REDIS_KEEP_ALIVE, 10)
+                        : undefined
             })
         }
     }

--- a/packages/server/src/queue/RedisEventSubscriber.ts
+++ b/packages/server/src/queue/RedisEventSubscriber.ts
@@ -15,7 +15,11 @@ export class RedisEventSubscriber {
                         process.env.REDIS_KEEP_ALIVE && !isNaN(parseInt(process.env.REDIS_KEEP_ALIVE, 10))
                             ? parseInt(process.env.REDIS_KEEP_ALIVE, 10)
                             : undefined
-                }
+                },
+                pingInterval:
+                    process.env.REDIS_KEEP_ALIVE && !isNaN(parseInt(process.env.REDIS_KEEP_ALIVE, 10))
+                        ? parseInt(process.env.REDIS_KEEP_ALIVE, 10)
+                        : undefined
             })
         } else {
             this.redisSubscriber = createClient({
@@ -32,7 +36,11 @@ export class RedisEventSubscriber {
                         process.env.REDIS_KEEP_ALIVE && !isNaN(parseInt(process.env.REDIS_KEEP_ALIVE, 10))
                             ? parseInt(process.env.REDIS_KEEP_ALIVE, 10)
                             : undefined
-                }
+                },
+                pingInterval:
+                    process.env.REDIS_KEEP_ALIVE && !isNaN(parseInt(process.env.REDIS_KEEP_ALIVE, 10))
+                        ? parseInt(process.env.REDIS_KEEP_ALIVE, 10)
+                        : undefined
             })
         }
         this.sseStreamer = sseStreamer

--- a/packages/ui/src/ui-component/cards/ItemCard.jsx
+++ b/packages/ui/src/ui-component/cards/ItemCard.jsx
@@ -3,10 +3,11 @@ import { useSelector } from 'react-redux'
 
 // material-ui
 import { styled } from '@mui/material/styles'
-import { Box, Grid, Typography, useTheme } from '@mui/material'
+import { Box, Grid, Tooltip, Typography, useTheme } from '@mui/material'
 
 // project imports
 import MainCard from '@/ui-component/cards/MainCard'
+import MoreItemsTooltip from '../tooltip/MoreItemsTooltip'
 
 const CardWrapper = styled(MainCard)(({ theme }) => ({
     background: theme.palette.card.main,
@@ -116,48 +117,63 @@ const ItemCard = ({ data, images, icons, onClick }) => {
                             }}
                         >
                             {[
-                                ...(images || []).map((img) => ({ type: 'image', src: img })),
-                                ...(icons || []).map((ic) => ({ type: 'icon', icon: ic.icon, color: ic.color }))
+                                ...(images || []).map((img) => ({ type: 'image', src: img.imageSrc, label: img.label })),
+                                ...(icons || []).map((ic) => ({ type: 'icon', icon: ic.icon, color: ic.color, label: ic.name }))
                             ]
                                 .slice(0, 3)
-                                .map((item, index) =>
-                                    item.type === 'image' ? (
-                                        <Box
-                                            key={item.src}
-                                            sx={{
-                                                width: 30,
-                                                height: 30,
-                                                borderRadius: '50%',
-                                                backgroundColor: customization.isDarkMode
-                                                    ? theme.palette.common.white
-                                                    : theme.palette.grey[300] + 75
-                                            }}
-                                        >
-                                            <img
-                                                style={{ width: '100%', height: '100%', padding: 5, objectFit: 'contain' }}
-                                                alt=''
-                                                src={item.src}
-                                            />
-                                        </Box>
-                                    ) : (
-                                        <div
-                                            key={index}
-                                            style={{
-                                                width: 30,
-                                                height: 30,
-                                                display: 'flex',
-                                                alignItems: 'center',
-                                                justifyContent: 'center'
-                                            }}
-                                        >
-                                            <item.icon size={25} color={item.color} />
-                                        </div>
-                                    )
-                                )}
-                            {images?.length + (icons?.length || 0) > 3 && (
-                                <Typography sx={{ alignItems: 'center', display: 'flex', fontSize: '.9rem', fontWeight: 200 }}>
-                                    + {images?.length + (icons?.length || 0) - 3} More
-                                </Typography>
+                                .map((item, index) => (
+                                    <Tooltip key={item.src || index} title={item.label} placement='top'>
+                                        {item.type === 'image' ? (
+                                            <Box
+                                                sx={{
+                                                    width: 30,
+                                                    height: 30,
+                                                    borderRadius: '50%',
+                                                    backgroundColor: customization.isDarkMode
+                                                        ? theme.palette.common.white
+                                                        : theme.palette.grey[300] + 75
+                                                }}
+                                            >
+                                                <img
+                                                    style={{ width: '100%', height: '100%', padding: 5, objectFit: 'contain' }}
+                                                    alt=''
+                                                    src={item.src}
+                                                />
+                                            </Box>
+                                        ) : (
+                                            <div
+                                                style={{
+                                                    width: 30,
+                                                    height: 30,
+                                                    display: 'flex',
+                                                    alignItems: 'center',
+                                                    justifyContent: 'center'
+                                                }}
+                                            >
+                                                <item.icon size={25} color={item.color} />
+                                            </div>
+                                        )}
+                                    </Tooltip>
+                                ))}
+
+                            {(images?.length || 0) + (icons?.length || 0) > 3 && (
+                                <MoreItemsTooltip
+                                    images={[
+                                        ...(images?.slice(3) || []),
+                                        ...(icons?.slice(Math.max(0, 3 - (images?.length || 0))) || []).map((ic) => ({ label: ic.name }))
+                                    ]}
+                                >
+                                    <Typography
+                                        sx={{
+                                            alignItems: 'center',
+                                            display: 'flex',
+                                            fontSize: '.9rem',
+                                            fontWeight: 200
+                                        }}
+                                    >
+                                        + {(images?.length || 0) + (icons?.length || 0) - 3} More
+                                    </Typography>
+                                </MoreItemsTooltip>
                             )}
                         </Box>
                     )}

--- a/packages/ui/src/ui-component/table/FlowListTable.jsx
+++ b/packages/ui/src/ui-component/table/FlowListTable.jsx
@@ -25,6 +25,8 @@ import FlowListMenu from '../button/FlowListMenu'
 import { Link } from 'react-router-dom'
 import { useAuth } from '@/hooks/useAuth'
 
+import MoreItemsTooltip from '../tooltip/MoreItemsTooltip'
+
 const StyledTableCell = styled(TableCell)(({ theme }) => ({
     borderColor: theme.palette.grey[900] + 25,
 
@@ -234,64 +236,80 @@ export const FlowListTable = ({
                                                     }}
                                                 >
                                                     {[
-                                                        ...(images[row.id] || []).map((img) => ({ type: 'image', src: img })),
+                                                        ...(images[row.id] || []).map((img) => ({
+                                                            type: 'image',
+                                                            src: img.imageSrc,
+                                                            label: img.label
+                                                        })),
                                                         ...(icons[row.id] || []).map((ic) => ({
                                                             type: 'icon',
                                                             icon: ic.icon,
-                                                            color: ic.color
+                                                            color: ic.color,
+                                                            title: ic.name
                                                         }))
                                                     ]
                                                         .slice(0, 5)
-                                                        .map((item, index) =>
-                                                            item.type === 'image' ? (
-                                                                <Box
-                                                                    key={item.src}
-                                                                    sx={{
-                                                                        width: 30,
-                                                                        height: 30,
-                                                                        borderRadius: '50%',
-                                                                        backgroundColor: customization.isDarkMode
-                                                                            ? theme.palette.common.white
-                                                                            : theme.palette.grey[300] + 75
-                                                                    }}
-                                                                >
-                                                                    <img
-                                                                        style={{
-                                                                            width: '100%',
-                                                                            height: '100%',
-                                                                            padding: 5,
-                                                                            objectFit: 'contain'
+                                                        .map((item, index) => (
+                                                            <Tooltip key={item.imageSrc || index} title={item.label} placement='top'>
+                                                                {item.type === 'image' ? (
+                                                                    <Box
+                                                                        sx={{
+                                                                            width: 30,
+                                                                            height: 30,
+                                                                            borderRadius: '50%',
+                                                                            backgroundColor: customization.isDarkMode
+                                                                                ? theme.palette.common.white
+                                                                                : theme.palette.grey[300] + 75
                                                                         }}
-                                                                        alt=''
-                                                                        src={item.src}
-                                                                    />
-                                                                </Box>
-                                                            ) : (
-                                                                <div
-                                                                    key={index}
-                                                                    style={{
-                                                                        width: 30,
-                                                                        height: 30,
-                                                                        display: 'flex',
-                                                                        alignItems: 'center',
-                                                                        justifyContent: 'center'
-                                                                    }}
-                                                                >
-                                                                    <item.icon size={25} color={item.color} />
-                                                                </div>
-                                                            )
-                                                        )}
+                                                                    >
+                                                                        <img
+                                                                            style={{
+                                                                                width: '100%',
+                                                                                height: '100%',
+                                                                                padding: 5,
+                                                                                objectFit: 'contain'
+                                                                            }}
+                                                                            alt=''
+                                                                            src={item.src}
+                                                                        />
+                                                                    </Box>
+                                                                ) : (
+                                                                    <div
+                                                                        style={{
+                                                                            width: 30,
+                                                                            height: 30,
+                                                                            display: 'flex',
+                                                                            alignItems: 'center',
+                                                                            justifyContent: 'center'
+                                                                        }}
+                                                                    >
+                                                                        <item.icon size={25} color={item.color} />
+                                                                    </div>
+                                                                )}
+                                                            </Tooltip>
+                                                        ))}
+
                                                     {(images[row.id]?.length || 0) + (icons[row.id]?.length || 0) > 5 && (
-                                                        <Typography
-                                                            sx={{
-                                                                alignItems: 'center',
-                                                                display: 'flex',
-                                                                fontSize: '.9rem',
-                                                                fontWeight: 200
-                                                            }}
+                                                        <MoreItemsTooltip
+                                                            images={[
+                                                                ...(images[row.id]?.slice(5) || []),
+                                                                ...(
+                                                                    icons[row.id]?.slice(Math.max(0, 5 - (images[row.id]?.length || 0))) ||
+                                                                    []
+                                                                ).map((ic) => ({ label: ic.name }))
+                                                            ]}
                                                         >
-                                                            + {(images[row.id]?.length || 0) + (icons[row.id]?.length || 0) - 5} More
-                                                        </Typography>
+                                                            <Typography
+                                                                sx={{
+                                                                    alignItems: 'center',
+                                                                    display: 'flex',
+                                                                    fontSize: '.9rem',
+                                                                    fontWeight: 200
+                                                                }}
+                                                            >
+                                                                + {(images[row.id]?.length || 0) + (icons[row.id]?.length || 0) - 5} More
+                                                            </Typography>
+                                                        </MoreItemsTooltip>
                                                     )}
                                                 </Box>
                                             )}

--- a/packages/ui/src/ui-component/tooltip/MoreItemsTooltip.jsx
+++ b/packages/ui/src/ui-component/tooltip/MoreItemsTooltip.jsx
@@ -1,0 +1,40 @@
+import { Tooltip, Typography } from '@mui/material'
+import { styled } from '@mui/material/styles'
+import PropTypes from 'prop-types'
+
+const StyledOl = styled('ol')(() => ({
+    paddingLeft: 20,
+    margin: 0
+}))
+
+const StyledLi = styled('li')(() => ({
+    paddingBottom: 4
+}))
+
+const MoreItemsTooltip = ({ images, children }) => {
+    if (!images || images.length === 0) return children
+
+    return (
+        <Tooltip
+            title={
+                <StyledOl>
+                    {images.map((img) => (
+                        <StyledLi key={img.imageSrc || img.label}>
+                            <Typography>{img.label}</Typography>
+                        </StyledLi>
+                    ))}
+                </StyledOl>
+            }
+            placement='top'
+        >
+            {children}
+        </Tooltip>
+    )
+}
+
+export default MoreItemsTooltip
+
+MoreItemsTooltip.propTypes = {
+    images: PropTypes.array,
+    children: PropTypes.node
+}

--- a/packages/ui/src/views/agentflows/index.jsx
+++ b/packages/ui/src/views/agentflows/index.jsx
@@ -117,13 +117,17 @@ const Agentflows = () => {
                     images[agentflows[i].id] = []
                     icons[agentflows[i].id] = []
                     for (let j = 0; j < nodes.length; j += 1) {
+                        if (nodes[j].data.name === 'stickyNote' || nodes[j].data.name === 'stickyNoteAgentflow') continue
                         const foundIcon = AGENTFLOW_ICONS.find((icon) => icon.name === nodes[j].data.name)
                         if (foundIcon) {
                             icons[agentflows[i].id].push(foundIcon)
                         } else {
                             const imageSrc = `${baseURL}/api/v1/node-icon/${nodes[j].data.name}`
-                            if (!images[agentflows[i].id].includes(imageSrc)) {
-                                images[agentflows[i].id].push(imageSrc)
+                            if (!images[agentflows[i].id].some((img) => img.imageSrc === imageSrc)) {
+                                images[agentflows[i].id].push({
+                                    imageSrc,
+                                    label: nodes[j].data.label
+                                })
                             }
                         }
                     }

--- a/packages/ui/src/views/agentflowsv2/Canvas.jsx
+++ b/packages/ui/src/views/agentflowsv2/Canvas.jsx
@@ -42,7 +42,7 @@ import useApi from '@/hooks/useApi'
 import useConfirm from '@/hooks/useConfirm'
 
 // icons
-import { IconX, IconRefreshAlert } from '@tabler/icons-react'
+import { IconX, IconRefreshAlert, IconMagnetFilled, IconMagnetOff } from '@tabler/icons-react'
 
 // utils
 import {
@@ -100,6 +100,7 @@ const AgentflowCanvas = () => {
     const [isSyncNodesButtonEnabled, setIsSyncNodesButtonEnabled] = useState(false)
     const [editNodeDialogOpen, setEditNodeDialogOpen] = useState(false)
     const [editNodeDialogProps, setEditNodeDialogProps] = useState({})
+    const [isSnappingEnabled, setIsSnappingEnabled] = useState(false)
 
     const reactFlowWrapper = useRef(null)
 
@@ -718,17 +719,30 @@ const AgentflowCanvas = () => {
                                 fitView
                                 deleteKeyCode={canvas.canvasDialogShow ? null : ['Delete']}
                                 minZoom={0.5}
+                                snapGrid={[25, 25]}
+                                snapToGrid={isSnappingEnabled}
                                 connectionLineComponent={ConnectionLine}
                             >
                                 <Controls
+                                    className={customization.isDarkMode ? 'dark-mode-controls' : ''}
                                     style={{
                                         display: 'flex',
                                         flexDirection: 'row',
                                         left: '50%',
-                                        transform: 'translate(-50%, -50%)',
-                                        backgroundColor: customization.isDarkMode ? theme.palette.background.default : '#fff'
+                                        transform: 'translate(-50%, -50%)'
                                     }}
-                                />
+                                >
+                                    <button
+                                        className='react-flow__controls-button react-flow__controls-interactive'
+                                        onClick={() => {
+                                            setIsSnappingEnabled(!isSnappingEnabled)
+                                        }}
+                                        title='toggle snapping'
+                                        aria-label='toggle snapping'
+                                    >
+                                        {isSnappingEnabled ? <IconMagnetFilled /> : <IconMagnetOff />}
+                                    </button>
+                                </Controls>
                                 <MiniMap
                                     nodeStrokeWidth={3}
                                     nodeColor={customization.isDarkMode ? '#2d2d2d' : '#e2e2e2'}

--- a/packages/ui/src/views/agentflowsv2/MarketplaceCanvas.jsx
+++ b/packages/ui/src/views/agentflowsv2/MarketplaceCanvas.jsx
@@ -4,6 +4,7 @@ import 'reactflow/dist/style.css'
 import '@/views/canvas/index.css'
 
 import { useLocation, useNavigate } from 'react-router-dom'
+import { useSelector } from 'react-redux'
 
 // material-ui
 import { Toolbar, Box, AppBar } from '@mui/material'
@@ -18,6 +19,9 @@ import StickyNote from './StickyNote'
 import EditNodeDialog from '@/views/agentflowsv2/EditNodeDialog'
 import { flowContext } from '@/store/context/ReactFlowContext'
 
+// icons
+import { IconMagnetFilled, IconMagnetOff } from '@tabler/icons-react'
+
 const nodeTypes = { agentFlow: AgentFlowNode, stickyNote: StickyNote, iteration: IterationNode }
 const edgeTypes = { agentFlow: AgentFlowEdge }
 
@@ -26,6 +30,7 @@ const edgeTypes = { agentFlow: AgentFlowEdge }
 const MarketplaceCanvasV2 = () => {
     const theme = useTheme()
     const navigate = useNavigate()
+    const customization = useSelector((state) => state.customization)
 
     const { state } = useLocation()
     const { flowData, name } = state
@@ -36,6 +41,7 @@ const MarketplaceCanvasV2 = () => {
     const [edges, setEdges, onEdgesChange] = useEdgesState()
     const [editNodeDialogOpen, setEditNodeDialogOpen] = useState(false)
     const [editNodeDialogProps, setEditNodeDialogProps] = useState({})
+    const [isSnappingEnabled, setIsSnappingEnabled] = useState(false)
 
     const reactFlowWrapper = useRef(null)
     const { setReactFlowInstance } = useContext(flowContext)
@@ -108,15 +114,29 @@ const MarketplaceCanvasV2 = () => {
                                 edgeTypes={edgeTypes}
                                 fitView
                                 minZoom={0.1}
+                                snapGrid={[25, 25]}
+                                snapToGrid={isSnappingEnabled}
                             >
                                 <Controls
+                                    className={customization.isDarkMode ? 'dark-mode-controls' : ''}
                                     style={{
                                         display: 'flex',
                                         flexDirection: 'row',
                                         left: '50%',
                                         transform: 'translate(-50%, -50%)'
                                     }}
-                                />
+                                >
+                                    <button
+                                        className='react-flow__controls-button react-flow__controls-interactive'
+                                        onClick={() => {
+                                            setIsSnappingEnabled(!isSnappingEnabled)
+                                        }}
+                                        title='toggle snapping'
+                                        aria-label='toggle snapping'
+                                    >
+                                        {isSnappingEnabled ? <IconMagnetFilled /> : <IconMagnetOff />}
+                                    </button>
+                                </Controls>
                                 <Background color='#aaa' gap={16} />
                                 <EditNodeDialog
                                     show={editNodeDialogOpen}

--- a/packages/ui/src/views/agentflowsv2/index.css
+++ b/packages/ui/src/views/agentflowsv2/index.css
@@ -54,3 +54,42 @@
     stroke-width: 3 !important;
     opacity: 1;
 }
+
+/* Dark mode controls styling */
+.dark-mode-controls {
+    --xy-controls-button-background-color-default: #2d2d2d;
+    --xy-controls-button-background-color-hover-default: #404040;
+    --xy-controls-button-border-color-default: #525252;
+    --xy-controls-box-shadow-default: 0 0 2px 1px rgba(255, 255, 255, 0.1);
+}
+
+.dark-mode-controls .react-flow__controls-button {
+    background-color: #2d2d2d;
+    border-color: #525252;
+    color: #ffffff;
+    border: 1px solid #525252;
+}
+
+.dark-mode-controls .react-flow__controls-button:hover {
+    background-color: #404040;
+}
+
+.dark-mode-controls .react-flow__controls-button.react-flow__controls-interactive {
+    background-color: #2d2d2d;
+    border-color: #525252;
+    color: #ffffff;
+}
+
+.dark-mode-controls .react-flow__controls-button.react-flow__controls-interactive:hover {
+    background-color: #404040;
+}
+
+.dark-mode-controls .react-flow__controls-button svg {
+    color: #ffffff;
+    fill: #ffffff;
+}
+
+.dark-mode-controls .react-flow__controls-button:hover svg {
+    color: #ffffff;
+    fill: #ffffff;
+}

--- a/packages/ui/src/views/canvas/index.css
+++ b/packages/ui/src/views/canvas/index.css
@@ -47,3 +47,42 @@
     cursor: crosshair;
     background: #5dba62 !important;
 }
+
+/* Dark mode controls styling */
+.dark-mode-controls {
+    --xy-controls-button-background-color-default: #2d2d2d;
+    --xy-controls-button-background-color-hover-default: #404040;
+    --xy-controls-button-border-color-default: #525252;
+    --xy-controls-box-shadow-default: 0 0 2px 1px rgba(255, 255, 255, 0.1);
+}
+
+.dark-mode-controls .react-flow__controls-button {
+    background-color: #2d2d2d;
+    border-color: #525252;
+    color: #ffffff;
+    border: 1px solid #525252;
+}
+
+.dark-mode-controls .react-flow__controls-button:hover {
+    background-color: #404040;
+}
+
+.dark-mode-controls .react-flow__controls-button.react-flow__controls-interactive {
+    background-color: #2d2d2d;
+    border-color: #525252;
+    color: #ffffff;
+}
+
+.dark-mode-controls .react-flow__controls-button.react-flow__controls-interactive:hover {
+    background-color: #404040;
+}
+
+.dark-mode-controls .react-flow__controls-button svg {
+    color: #ffffff;
+    fill: #ffffff;
+}
+
+.dark-mode-controls .react-flow__controls-button:hover svg {
+    color: #ffffff;
+    fill: #ffffff;
+}

--- a/packages/ui/src/views/canvas/index.jsx
+++ b/packages/ui/src/views/canvas/index.jsx
@@ -38,7 +38,7 @@ import useConfirm from '@/hooks/useConfirm'
 import { useAuth } from '@/hooks/useAuth'
 
 // icons
-import { IconX, IconRefreshAlert } from '@tabler/icons-react'
+import { IconX, IconRefreshAlert, IconMagnetFilled, IconMagnetOff } from '@tabler/icons-react'
 
 // utils
 import {
@@ -77,6 +77,7 @@ const Canvas = () => {
     const { confirm } = useConfirm()
 
     const dispatch = useDispatch()
+    const customization = useSelector((state) => state.customization)
     const canvas = useSelector((state) => state.canvas)
     const [canvasDataStore, setCanvasDataStore] = useState(canvas)
     const [chatflow, setChatflow] = useState(null)
@@ -96,6 +97,7 @@ const Canvas = () => {
     const [selectedNode, setSelectedNode] = useState(null)
     const [isUpsertButtonEnabled, setIsUpsertButtonEnabled] = useState(false)
     const [isSyncNodesButtonEnabled, setIsSyncNodesButtonEnabled] = useState(false)
+    const [isSnappingEnabled, setIsSnappingEnabled] = useState(false)
 
     const reactFlowWrapper = useRef(null)
 
@@ -596,16 +598,30 @@ const Canvas = () => {
                                 fitView
                                 deleteKeyCode={canvas.canvasDialogShow ? null : ['Delete']}
                                 minZoom={0.1}
+                                snapGrid={[25, 25]}
+                                snapToGrid={isSnappingEnabled}
                                 className='chatflow-canvas'
                             >
                                 <Controls
+                                    className={customization.isDarkMode ? 'dark-mode-controls' : ''}
                                     style={{
                                         display: 'flex',
                                         flexDirection: 'row',
                                         left: '50%',
                                         transform: 'translate(-50%, -50%)'
                                     }}
-                                />
+                                >
+                                    <button
+                                        className='react-flow__controls-button react-flow__controls-interactive'
+                                        onClick={() => {
+                                            setIsSnappingEnabled(!isSnappingEnabled)
+                                        }}
+                                        title='toggle snapping'
+                                        aria-label='toggle snapping'
+                                    >
+                                        {isSnappingEnabled ? <IconMagnetFilled /> : <IconMagnetOff />}
+                                    </button>
+                                </Controls>
                                 <Background color='#aaa' gap={16} />
                                 <AddNodes isAgentCanvas={isAgentCanvas} nodesData={getNodesApi.data} node={selectedNode} />
                                 {isSyncNodesButtonEnabled && (

--- a/packages/ui/src/views/chatflows/index.jsx
+++ b/packages/ui/src/views/chatflows/index.jsx
@@ -89,9 +89,13 @@ const Chatflows = () => {
                     const nodes = flowData.nodes || []
                     images[chatflows[i].id] = []
                     for (let j = 0; j < nodes.length; j += 1) {
+                        if (nodes[j].data.name === 'stickyNote' || nodes[j].data.name === 'stickyNoteAgentflow') continue
                         const imageSrc = `${baseURL}/api/v1/node-icon/${nodes[j].data.name}`
-                        if (!images[chatflows[i].id].includes(imageSrc)) {
-                            images[chatflows[i].id].push(imageSrc)
+                        if (!images[chatflows[i].id].some((img) => img.imageSrc === imageSrc)) {
+                            images[chatflows[i].id].push({
+                                imageSrc,
+                                label: nodes[j].data.label
+                            })
                         }
                     }
                 }

--- a/packages/ui/src/views/marketplaces/MarketplaceCanvas.jsx
+++ b/packages/ui/src/views/marketplaces/MarketplaceCanvas.jsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import ReactFlow, { Controls, Background, useNodesState, useEdgesState } from 'reactflow'
 import 'reactflow/dist/style.css'
 import '@/views/canvas/index.css'
 
 import { useLocation, useNavigate } from 'react-router-dom'
+import { useSelector } from 'react-redux'
 
 // material-ui
 import { Toolbar, Box, AppBar } from '@mui/material'
@@ -14,6 +15,9 @@ import MarketplaceCanvasNode from './MarketplaceCanvasNode'
 import MarketplaceCanvasHeader from './MarketplaceCanvasHeader'
 import StickyNote from '../canvas/StickyNote'
 
+// icons
+import { IconMagnetFilled, IconMagnetOff } from '@tabler/icons-react'
+
 const nodeTypes = { customNode: MarketplaceCanvasNode, stickyNote: StickyNote }
 const edgeTypes = { buttonedge: '' }
 
@@ -22,15 +26,16 @@ const edgeTypes = { buttonedge: '' }
 const MarketplaceCanvas = () => {
     const theme = useTheme()
     const navigate = useNavigate()
+    const customization = useSelector((state) => state.customization)
 
     const { state } = useLocation()
-    const flowData = state?.flowData || '{}'
-    const name = state?.name || 'Untitled'
+    const { flowData, name } = state
 
     // ==============================|| ReactFlow ||============================== //
 
     const [nodes, setNodes, onNodesChange] = useNodesState()
     const [edges, setEdges, onEdgesChange] = useEdgesState()
+    const [isSnappingEnabled, setIsSnappingEnabled] = useState(false)
 
     const reactFlowWrapper = useRef(null)
 
@@ -87,15 +92,29 @@ const MarketplaceCanvas = () => {
                                 edgeTypes={edgeTypes}
                                 fitView
                                 minZoom={0.1}
+                                snapGrid={[25, 25]}
+                                snapToGrid={isSnappingEnabled}
                             >
                                 <Controls
+                                    className={customization.isDarkMode ? 'dark-mode-controls' : ''}
                                     style={{
                                         display: 'flex',
                                         flexDirection: 'row',
                                         left: '50%',
                                         transform: 'translate(-50%, -50%)'
                                     }}
-                                />
+                                >
+                                    <button
+                                        className='react-flow__controls-button react-flow__controls-interactive'
+                                        onClick={() => {
+                                            setIsSnappingEnabled(!isSnappingEnabled)
+                                        }}
+                                        title='toggle snapping'
+                                        aria-label='toggle snapping'
+                                    >
+                                        {isSnappingEnabled ? <IconMagnetFilled /> : <IconMagnetOff />}
+                                    </button>
+                                </Controls>
                                 <Background color='#aaa' gap={16} />
                             </ReactFlow>
                         </div>

--- a/packages/ui/src/views/marketplaces/index.jsx
+++ b/packages/ui/src/views/marketplaces/index.jsx
@@ -375,13 +375,17 @@ const Marketplace = () => {
                         images[flows[i].id] = []
                         icons[flows[i].id] = []
                         for (let j = 0; j < nodes.length; j += 1) {
+                            if (nodes[j].data.name === 'stickyNote' || nodes[j].data.name === 'stickyNoteAgentflow') continue
                             const foundIcon = AGENTFLOW_ICONS.find((icon) => icon.name === nodes[j].data.name)
                             if (foundIcon) {
                                 icons[flows[i].id].push(foundIcon)
                             } else {
                                 const imageSrc = `${baseURL}/api/v1/node-icon/${nodes[j].data.name}`
-                                if (!images[flows[i].id].includes(imageSrc)) {
-                                    images[flows[i].id].push(imageSrc)
+                                if (!images[flows[i].id].some((img) => img.imageSrc === imageSrc)) {
+                                    images[flows[i].id].push({
+                                        imageSrc,
+                                        label: nodes[j].data.name
+                                    })
                                 }
                             }
                         }


### PR DESCRIPTION
Feature: add tooltip display on icon hover in chatflows and marketplace page

* feat: add tooltip display on icon hover in chatflows and marketplace page

* update list view, remove sticky note images

---------

Feature: extends ReactFlow controls with snapping functionality

* Feature: extends ReactFlow controls with snapping functionality

* Adds snapping on other flows

* lint fix, add dark mode, fix marketplace canvas

---------

Fix: Patching redis socket crash fix (#208)

* redis keepalive mechanism for all redis

* removed offline queue commands

* Simplified changes for consistency. Added REDIS_KEEP_ALIVE env variable.

* update redis socket alive env variable

* lint fix

* put pingInterval back again because it's needed

* removed comment

* linting

---------