### PR TITLE
Chore/Prevent reading runtime vars for cloud

### DIFF
--- a/packages/components/nodes/agentflow/Agent/Agent.ts
+++ b/packages/components/nodes/agentflow/Agent/Agent.ts
@@ -1412,6 +1412,7 @@ class Agent_Agentflow implements INode {
                     (selectedTool as any).requiresHumanInput && (!iterationContext || Object.keys(iterationContext).length === 0)
 
                 const flowConfig = {
+                    chatflowId: options.chatflowid,
                     sessionId: options.sessionId,
                     chatId: options.chatId,
                     input: input,
@@ -1679,6 +1680,7 @@ class Agent_Agentflow implements INode {
                 let parsedArtifacts
 
                 const flowConfig = {
+                    chatflowId: options.chatflowid,
                     sessionId: options.sessionId,
                     chatId: options.chatId,
                     input: input,

--- a/packages/components/nodes/agentflow/ExecuteFlow/ExecuteFlow.ts
+++ b/packages/components/nodes/agentflow/ExecuteFlow/ExecuteFlow.ts
@@ -30,7 +30,7 @@ class ExecuteFlow_Agentflow implements INode {
     constructor() {
         this.label = 'Execute Flow'
         this.name = 'executeFlowAgentflow'
-        this.version = 1.0
+        this.version = 1.1
         this.type = 'ExecuteFlow'
         this.category = 'Agent Flows'
         this.description = 'Execute another flow'
@@ -62,7 +62,8 @@ class ExecuteFlow_Agentflow implements INode {
                 name: 'executeFlowOverrideConfig',
                 description: 'Override the config passed to the flow',
                 type: 'json',
-                optional: true
+                optional: true,
+                acceptVariable: true
             },
             {
                 label: 'Base URL',
@@ -162,12 +163,17 @@ class ExecuteFlow_Agentflow implements INode {
         const flowInput = nodeData.inputs?.executeFlowInput as string
         const returnResponseAs = nodeData.inputs?.executeFlowReturnResponseAs as string
         const _executeFlowUpdateState = nodeData.inputs?.executeFlowUpdateState
-        const overrideConfig =
-            typeof nodeData.inputs?.executeFlowOverrideConfig === 'string' &&
-            nodeData.inputs.executeFlowOverrideConfig.startsWith('{') &&
-            nodeData.inputs.executeFlowOverrideConfig.endsWith('}')
-                ? JSON.parse(nodeData.inputs.executeFlowOverrideConfig)
-                : nodeData.inputs?.executeFlowOverrideConfig
+
+        let overrideConfig = nodeData.inputs?.executeFlowOverrideConfig
+        if (typeof overrideConfig === 'string' && overrideConfig.startsWith('{') && overrideConfig.endsWith('}')) {
+            try {
+                // Handle escaped square brackets and other common escape sequences
+                const unescapedConfig = overrideConfig.replace(/\\(\[|\])/g, '$1')
+                overrideConfig = JSON.parse(unescapedConfig)
+            } catch (parseError) {
+                throw new Error(`Invalid JSON in executeFlowOverrideConfig: ${parseError.message}`)
+            }
+        }
 
         const state = options.agentflowRuntime?.state as ICommonObject
         const runtimeChatHistory = (options.agentflowRuntime?.chatHistory as BaseMessageLike[]) ?? []

--- a/packages/components/nodes/agentflow/Tool/Tool.ts
+++ b/packages/components/nodes/agentflow/Tool/Tool.ts
@@ -274,6 +274,7 @@ class Tool_Agentflow implements INode {
         }
 
         const flowConfig = {
+            chatflowId: options.chatflowid,
             sessionId: options.sessionId,
             chatId: options.chatId,
             input: input,

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -1378,11 +1378,10 @@ export const findAvailableConfigs = (reactFlowNodes: IReactFlowNode[], component
                 }
                 continue
             } else if (inputParam.type === 'array') {
-                // get array item schema
                 const arrayItem = inputParam.array
                 if (Array.isArray(arrayItem)) {
-                    const arraySchema = []
-                    // Each array item is a field definition
+                    const arrayItemSchema: Record<string, string> = {}
+                    // Build object schema representing the structure of each array item
                     for (const item of arrayItem) {
                         let itemType = item.type
                         if (itemType === 'options') {
@@ -1391,10 +1390,7 @@ export const findAvailableConfigs = (reactFlowNodes: IReactFlowNode[], component
                         } else if (itemType === 'file') {
                             itemType = item.fileType ?? item.type
                         }
-                        arraySchema.push({
-                            name: item.name,
-                            type: itemType
-                        })
+                        arrayItemSchema[item.name] = itemType
                     }
                     obj = {
                         node: flowNode.data.label,
@@ -1402,7 +1398,7 @@ export const findAvailableConfigs = (reactFlowNodes: IReactFlowNode[], component
                         label: inputParam.label,
                         name: inputParam.name,
                         type: inputParam.type,
-                        schema: arraySchema
+                        schema: arrayItemSchema
                     }
                 }
             } else if (inputParam.loadConfig) {


### PR DESCRIPTION
Chore/Prevent reading runtime vars for cloud

prevent reading runtime vars for cloud

Feature/Add chatflowId To Config

* allow overrideconfig from executeflow node to take in variables

* update array object schema

* add chatflowId to config

Feature/Allow overrideconfig from executeflow node to take in variables (#255)

* allow overrideconfig from executeflow node to take in variables

* update array object schema